### PR TITLE
RESTClient: return the error code for an error

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -196,9 +196,9 @@ class RESTClient {
                       `code=${code} ret=${ret}`);
             return callback(null, ret);
         }
-        const error = new Error(res.statusCode);
+        const error = new Error(res.statusMessage);
         error.isExpected = true;
-        error.message = res.statusMessage;
+        error.code = code;
         log.debug(`direct request to endpoint returned an expected ` +
                   `error code=${res.statusCode} ret=${res.statusMessage}`);
         return callback(error, ret);

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -72,6 +72,7 @@ describe('Unit tests with mockup server', function tests() {
             if (err) {
                 const error = new Error('BucketAlreadyExists');
                 error.isExpected = true;
+                error.code = 409;
                 assert.deepStrictEqual(err, error);
                 return done();
             }
@@ -95,10 +96,11 @@ describe('Unit tests with mockup server', function tests() {
         });
     });
 
-    it('should get Raft informations on an existing bucket', done => {
+    it('should get Raft informations on an unexisting bucket', done => {
         client.getRaftInformation(nonExistBucket.name, reqUids, (err, data) => {
             const error = new Error('NoSuchBucket');
             error.isExpected = true;
+            error.code = 404;
             assert.deepStrictEqual(err, error);
             return done();
             done(err);
@@ -110,6 +112,7 @@ describe('Unit tests with mockup server', function tests() {
             if (err) {
                 const error = new Error('NoSuchBucket');
                 error.isExpected = true;
+                error.code = 404;
                 assert.deepStrictEqual(err, error);
                 return done();
             }
@@ -126,6 +129,7 @@ describe('Unit tests with mockup server', function tests() {
             if (err) {
                 const error = new Error('NoSuchBucket');
                 error.isExpected = true;
+                error.code = 404;
                 assert.deepStrictEqual(err, error);
                 return done();
             }


### PR DESCRIPTION
The endRespond returned the error.message but no the error code .
the constructor of new error puted the code who is override after.
Now the constructor take the message and add the code after
