### PR TITLE
FT: Enable keep alive sockets for connection pooling

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -15,6 +15,7 @@ class RESTClient {
         this.bootstrap = shuffle(this.bootstrap);
         this.setCurrentBootstrap(this.bootstrap[0]);
         this.port = 9000;
+        this.httpAgent = new http.Agent({ keepAlive: true });
     }
 
     _shiftCurrentBootstrapToEnd() {
@@ -141,6 +142,7 @@ class RESTClient {
             path,
             host: this.getCurrentBootstrap(),
             port: this.getPort(),
+            agent: this.httpAgent,
         };
         let ret = '';
         const req = http.request(option);


### PR DESCRIPTION
Enabling keep alive fixes the max connection errors issue while using
the client.
