### PR TITLE
feature(client): forward request UID to DBD

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -37,66 +37,71 @@ class RESTClient {
         return this.port;
     }
 
-    getBucketLeader(bucketName, callback) {
+    getBucketLeader(bucketName, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
-        this._failover(0, 'GET', `/default/leader/${bucketName}`, callback);
+        this._failover(0, 'GET', `/default/leader/${bucketName}`, reqUids,
+                       callback);
     }
 
-    getBucketAttributes(bucketName, callback) {
+    getBucketAttributes(bucketName, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
-        this._failover(0, 'GET', `/default/attributes/${bucketName}`, callback);
+        this._failover(0, 'GET', `/default/attributes/${bucketName}`, reqUids,
+                       callback);
     }
 
-    putBucketAttributes(bucketName, attributes, callback) {
+    putBucketAttributes(bucketName, reqUids, attributes, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof attributes === 'string', 'attributes must be a string');
-        this._failover(0, 'POST', `/default/attributes/${bucketName}`,
+        this._failover(0, 'POST', `/default/attributes/${bucketName}`, reqUids,
                 attributes, callback);
     }
 
-    createBucket(bucketName, attributes, callback) {
+    createBucket(bucketName, reqUids, attributes, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof attributes === 'string', 'attributes must be a string');
-        this._failover(0, 'POST', `/default/bucket/${bucketName}`,
+        this._failover(0, 'POST', `/default/bucket/${bucketName}`, reqUids,
                 attributes, callback);
     }
 
-    deleteBucket(bucketName, callback) {
+    deleteBucket(bucketName, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
-        this._failover(0, 'DELETE', `/default/bucket/${bucketName}`, callback);
+        this._failover(0, 'DELETE', `/default/bucket/${bucketName}`, reqUids,
+                       callback);
     }
 
-    putObject(bucketName, objName, objVal, cb) {
+    putObject(bucketName, objName, objVal, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         assert(typeof objVal === 'string', 'objVal must be a string');
         let path = `/default/bucket/${bucketName}/`;
         path += objName.replace(/\//g, '%2F');
-        this._failover(0, 'POST', path, JSON.stringify({ data: objVal }), cb);
+        this._failover(0, 'POST', path, reqUids,
+                       JSON.stringify({ data: objVal }), callback);
     }
 
-    getObject(bucketName, objName, callback) {
+    getObject(bucketName, objName, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
         path += objName.replace(/\//g, '%2F');
-        this._failover(0, 'GET', path, callback);
+        this._failover(0, 'GET', path, reqUids, callback);
     }
 
-    deleteObject(bucketName, objName, callback) {
+    deleteObject(bucketName, objName, reqUids, callback) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
         path += objName.replace(/\//g, '%2F');
-        this._failover(0, 'DELETE', path, callback);
+        this._failover(0, 'DELETE', path, reqUids, callback);
     }
 
-    listObject(bucketName, params, cb) {
+    listObject(bucketName, reqUids, params, cb) {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         if (cb !== undefined) {
             assert(typeof params === 'object', 'params must be an object');
         }
-        this._failover(0, 'GET', `/default/bucket/${bucketName}`, params, cb);
+        this._failover(0, 'GET', `/default/bucket/${bucketName}`, reqUids,
+                       params, cb);
     }
 
     endRespond(res, ret, callback) {
@@ -110,21 +115,22 @@ class RESTClient {
         return callback(error, ret);
     }
 
-    _failover(tries, method, beginPath, params, callback) {
+    _failover(tries, method, beginPath, reqUids, params, callback) {
         let count = tries;
-        this.request(method, beginPath, params, (err, data) => {
+        this.request(method, beginPath, reqUids, params, (err, data) => {
             if (err && !err.isExpected) {
                 if (++count >= this.bootstrap.length) {
                     return callback(err);
                 }
                 return this._shiftCurrentBootstrapToEnd()
-                    ._failover(count, method, beginPath, params, callback);
+                    ._failover(count, method, beginPath, reqUids,
+                               params, callback);
             }
             return callback(err, data);
         });
     }
 
-    request(method, beginPath, params, callback) {
+    request(method, beginPath, reqUids, params, callback) {
         let next;
         let path = beginPath;
         if (typeof params === 'function') {
@@ -137,9 +143,16 @@ class RESTClient {
                 && Object.keys(params).length !== 0) {
             path += `?${querystring.stringify(params)}`;
         }
+
+        const headers = {};
+        if (reqUids !== undefined) {
+            headers['x-scal-request-uids'] = reqUids;
+        }
+
         const option = {
             method,
             path,
+            headers,
             host: this.getCurrentBootstrap(),
             port: this.getPort(),
             agent: this.httpAgent,

--- a/tests/functional/client.js
+++ b/tests/functional/client.js
@@ -5,6 +5,7 @@ const BucketClient = require('../../index').RESTClient;
 
 const bucketName = 'HanSolo';
 const bucketAttributes = { status: 'dead' };
+const reqUids = 'REQ1';
 
 describe('Bucket Client tests', function testClient() {
     this.timeout(0);
@@ -15,12 +16,15 @@ describe('Bucket Client tests', function testClient() {
     });
 
     it('should create a new bucket', done => {
-        client.createBucket(bucketName, JSON.stringify(bucketAttributes),
-                            done);
+        client.createBucket(bucketName, reqUids,
+                            JSON.stringify(bucketAttributes), done);
     });
 
     it('should try to create the same bucket and fail', done => {
-        client.createBucket(bucketName, JSON.stringify(bucketAttributes),
+        client.createBucket(
+            bucketName,
+            reqUids,
+            JSON.stringify(bucketAttributes),
             err => {
                 if (err) {
                     const error = new Error(409);
@@ -31,9 +35,8 @@ describe('Bucket Client tests', function testClient() {
                 done('Did not fail as expected');
             });
     });
-
     it('should get the created bucket', done => {
-        client.getBucketAttributes(bucketName, (err, data) => {
+        client.getBucketAttributes(bucketName, reqUids, (err, data) => {
             const ret = JSON.parse(data);
             if (ret.status !== 'dead') {
                 return done(new Error('Did not fetch the data correctly'));
@@ -43,13 +46,13 @@ describe('Bucket Client tests', function testClient() {
     });
 
     it('should delete the created bucket', done => {
-        client.deleteBucket(bucketName, (err) => {
+        client.deleteBucket(bucketName, reqUids, (err) => {
             done(err);
         });
     });
 
     it('should fetch non-existing bucket, sending back an error', done => {
-        client.getBucketAttributes(bucketName, (err) => {
+        client.getBucketAttributes(bucketName, reqUids, (err) => {
             if (err) {
                 const error = new Error(404);
                 error.isExpected = true;

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -6,6 +6,7 @@ const RESTClient = require('../../index.js').RESTClient;
 
 const existBucket = { name: 'Zaphod', value: { status: 'alive' } };
 const nonExistBucket = { name: 'Ford' };
+const reqUids = 'REQ1';
 
 function makeResponse(res, code, message) {
     res.statusCode = code;
@@ -49,13 +50,12 @@ describe('Unit tests with mockup server', function tests() {
     afterEach('stop server', () => { server.close(); });
 
     it('should create a new non-existing bucket', done => {
-        client.createBucket(nonExistBucket.name, '{ status: "dead" }', (err) => {
-            done(err);
-        });
+        client.createBucket(nonExistBucket.name, reqUids,
+                            '{ status: "dead" }', done);
     });
 
     it('should try to create an already existing bucket and fail', done => {
-        client.createBucket(existBucket.name, '{}', (err) => {
+        client.createBucket(existBucket.name, reqUids, '{}', (err) => {
             if (err) {
                 const error = new Error('BucketAlreadyExists');
                 error.isExpected = true;
@@ -67,7 +67,7 @@ describe('Unit tests with mockup server', function tests() {
     });
 
     it('should get an existing bucket', done => {
-        client.getBucketAttributes(existBucket.name, (err, data) => {
+        client.getBucketAttributes(existBucket.name, reqUids, (err, data) => {
             const ret = JSON.parse(data);
             assert.deepStrictEqual(ret, existBucket.value);
             done(err);
@@ -75,7 +75,7 @@ describe('Unit tests with mockup server', function tests() {
     });
 
     it('should fetch non-existing bucket, sending back an error', done => {
-        client.getBucketAttributes(nonExistBucket.name, (err) => {
+        client.getBucketAttributes(nonExistBucket.name, reqUids, (err) => {
             if (err) {
                 const error = new Error('NoSuchBucket');
                 error.isExpected = true;
@@ -87,11 +87,11 @@ describe('Unit tests with mockup server', function tests() {
     });
 
     it('should delete an existing bucket', done => {
-        client.deleteBucket(existBucket.name, done);
+        client.deleteBucket(existBucket.name, reqUids, done);
     });
 
     it('should fetch non-existing bucket, sending back an error', done => {
-        client.deleteBucket(nonExistBucket.name, err => {
+        client.deleteBucket(nonExistBucket.name, reqUids, err => {
             if (err) {
                 const error = new Error('NoSuchBucket');
                 error.isExpected = true;


### PR DESCRIPTION
This breaking change adds a reqUids argument to all API methods,
in the last non-optional position before the callback argument.

Serialized per-request tags are now forwarded to DBD over HTTP
using the X-Scal-Request-Uids header.
