### PR TITLE
URI encode object key names

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -137,9 +137,9 @@ class RESTClient {
         assert(typeof objName === 'string', 'objName must be a string');
         assert(typeof objVal === 'string', 'objVal must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += objName.replace(/\//g, '%2F');
-
+        path += encodeURIComponent(objName);
         log.debug(`putObject ${bucketName}/${objName} val=${objVal}`);
+        log.debug(`path: ${path}`);
         this._failover(0, 'POST', path, log,
                        JSON.stringify({ data: objVal }), callback);
     }
@@ -149,9 +149,10 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += objName.replace(/\//g, '%2F');
+        path += encodeURIComponent(objName);
 
         log.debug(`getObject ${bucketName}/${objName}`);
+        log.debug(`path: ${path}`);
         this._failover(0, 'GET', path, log, callback);
     }
 
@@ -160,9 +161,10 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += objName.replace(/\//g, '%2F');
+        path += encodeURIComponent(objName);
 
         log.debug(`deleteObject ${bucketName}/${objName}`);
+        log.debug(`path: ${path}`);
         this._failover(0, 'DELETE', path, log, callback);
     }
 


### PR DESCRIPTION
This closes #19.

We should be URI encoding object keys in one place (and not selectively replacing individual characters).
This should be merged along with the dev/IntegrateMPU PR in metadata.
