### PR TITLE
Shell:(clean) use a request id required client

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -6,7 +6,15 @@ const RESTClient = require('./RESTClient');
 const host = process.argv[2] || 'localhost'
 const client = new RESTClient([host]);
 const bucket = {};
+const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
 let rl;
+
+function generateReqUid() {
+    let str = '';
+    for (let i = 0; i < 21; i++)
+        str += chars[Math.floor(Math.random() * (chars.length))];
+    return str;
+}
 
 const commands = [
     'createbucket ',
@@ -71,8 +79,9 @@ function createBucket(tab, callback) {
     if (tab.length !== 3) {
         callback('createbucket : usage : <bucket_name> <attributes>');
     } else {
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.createBucket(tab[1], tab[2], (err, data) => {
+        client.createBucket(tab[1], reqUids, tab[2], (err, data) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');
@@ -90,8 +99,9 @@ function deleteBucket(tab, callback) {
     } else {
         if (bucket[tab[1] + ' '] === undefined)
             bucket[tab[1] + ' '] = [];
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.deleteBucket(tab[1], (err, val) => {
+        client.deleteBucket(tab[1], reqUids, (err, val) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');
@@ -109,8 +119,9 @@ function putObject(tab, callback) {
     if (tab.length !== 4) {
         callback('putObject : usage : <bucket_name> <obj_name> <obj_value>');
     } else {
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.putObject(tab[1], tab[2], tab[3], (err, value) => {
+        client.putObject(tab[1], tab[2], tab[3], reqUids, (err, value) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');
@@ -129,7 +140,8 @@ function getBucketAttributes(tab, callback) {
     if (tab.length !== 2) {
         callback('getBucketAttributes: usage: <bucketName>');
     } else {
-        client.getBucketAttributes(tab[1], callback);
+        const reqUids = generateReqUid();
+        client.getBucketAttributes(tab[1], reqUids, callback);
     }
 }
 
@@ -138,8 +150,8 @@ function putBucketAttributes(tab, callback) {
         callback('putBucketAttributes: usage: '
                 + '<bucketName> <bucketAttributes>');
     } else {
-        const attributes = makeJSON(tab[2]);
-        client.putBucketAttributes(tab[1], attributes, callback);
+        const reqUids = generateReqUid();
+        client.putBucketAttributes(tab[1], reqUids, tab[2], callback);
     }
 }
 
@@ -147,8 +159,9 @@ function getObject(tab, callback) {
     if (tab.length !== 3) {
         callback('getObject : usage : <bucket_name> <obj_name>');
     } else {
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.getObject(tab[1], tab[2], (err, value) => {
+        client.getObject(tab[1], tab[2], reqUids, (err, value) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');
@@ -168,8 +181,9 @@ function deleteObject(tab, callback) {
     if (tab.length !== 3) {
         callback('getObject : usage : <bucket_name> <obj_name>');
     } else {
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.deleteObject(tab[1], tab[2], (err, value) => {
+        client.deleteObject(tab[1], tab[2], reqUids, (err, value) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');
@@ -199,8 +213,9 @@ function listObject(tab, callback) {
             }
             params[split[0]] = curVal.substring(listParams[index].length);
         });
+        const reqUids = generateReqUid();
         const begin = process.hrtime();
-        client.listObject(tab[1], params, (err, value) => {
+        client.listObject(tab[1], reqUids, params, (err, value) => {
             const end = process.hrtime(begin);
             rl.prompt();
             process.stdout.write('time : ' + end[1] / 1e6 + ' .ms\n');


### PR DESCRIPTION
With werelog integration lots of paramaters was add, but the shell
wasn't up to date with that.