### PR TITLE
Dev/cleanup/performance tweaks

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -247,13 +247,14 @@ class RESTClient {
             next = callback;
         }
         assert(typeof next === 'function', 'callback must be a function');
+        const headers = {};
+        headers['content-length'] = 0;
+        headers['x-scal-request-uids'] = log.getSerializedUids();
+
         if (method === 'GET' && typeof params === 'object'
                 && Object.keys(params).length !== 0) {
             path += `?${querystring.stringify(params)}`;
         }
-
-        const headers = {};
-        headers['x-scal-request-uids'] = log.getSerializedUids();
 
         const option = {
             method,
@@ -271,7 +272,10 @@ class RESTClient {
         const req = http.request(option);
 
         if (method === 'POST') {
-            req.write(params);
+            const rawData = new Buffer(params, 'binary');
+            headers['content-type'] = 'application/octet-stream';
+            headers['content-length'] = rawData.length;
+            req.write(rawData, 'binary');
         }
 
         const ret = [];


### PR DESCRIPTION
This PR includes commits for performance improvement by
- Use array push instead of string concatenation for combining chunks received (we saw ~ 10ms gain on this)
- Remove large objects being logged to the logger and cleanup logs from being formatted strings ( removing large objects from logs, especially on full listing with 1000 keys when trace/debug is enabled saw a gain of ~ 15ms) 
