### PR TITLE
Fix: Do not always return InternalError

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -20,7 +20,7 @@ function errorMap(mdError) {
         ObjNotFound: 'NoSuchKey',
         NotImplemented: 'NotImplemented',
     };
-    return map[mdError] ? map[mdError] : 'InternalError';
+    return map[mdError] ? map[mdError] : mdError;
 }
 
 class RESTClient {


### PR DESCRIPTION
- Return the metadata error in lieu of 'InternalError'.
