### PR TITLE
Performance improvements - use array, buffer.concat combine buffers

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -280,7 +280,8 @@ class RESTClient {
             port: this.getPort(),
             agent: this.httpAgent,
         };
-        let ret = '';
+        const ret = [];
+        let retLen = 0;
 
         // somehow option can get cyclical so fields need to be chosen
         // for display
@@ -294,9 +295,10 @@ class RESTClient {
 
         req.on('response', (res) => {
             res.on('data', (data) => {
-                ret += data.toString();
+                ret.push(data);
+                retLen += data.length;
             }).on('error', next).on('end', () => {
-                this.endRespond(res, ret, log, next);
+                this.endRespond(res, Buffer.concat(ret, retLen), log, next);
             });
         }).on('error', next).end();
     }


### PR DESCRIPTION
In order to avoid expensive mem. copies, encoding and to combine the buffers in
an efficient way we are favoring array, buffer.concat over string
concatenation of buffers.
