### PR TITLE
Performance Use binary buffers and content-length header

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -261,13 +261,15 @@ class RESTClient {
             next = callback;
         }
         assert(typeof next === 'function', 'callback must be a function');
+        const headers = {
+            'content-length': 0,
+            'x-scal-request-uids': log.getSerializedUids(),
+        };
+
         if (method === 'GET' && typeof params === 'object'
                 && Object.keys(params).length !== 0) {
             path += `?${querystring.stringify(params)}`;
         }
-
-        const headers = {};
-        headers['x-scal-request-uids'] = log.getSerializedUids();
 
         const option = {
             method,
@@ -287,7 +289,10 @@ class RESTClient {
         const req = http.request(option);
 
         if (method === 'POST') {
-            req.write(params);
+            const binData = new Buffer(params, 'binary');
+            req.setHeader('content-type', 'application/octet-stream');
+            req.setHeader('content-length', binData.length);
+            req.write(binData, 'binary');
         }
 
         req.on('response', (res) => {


### PR DESCRIPTION
Using binary buffers makes sure no data encoding takes place while
transferring payload to the server. Adding content-length ensures
transfer encoding is not chunked.
