### PR TITLE
cleanup: rename attributes  prop for log to attr

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -130,7 +130,7 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof attributes === 'string', 'attributes must be a string');
 
-        log.debug('putBucketAttributes', { bucketName, attributes });
+        log.debug('putBucketAttributes', { bucketName, attr: attributes });
         this._failover(0, 'POST', `/default/attributes/${bucketName}`, log,
                 attributes, callback);
     }
@@ -140,7 +140,7 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof attributes === 'string', 'attributes must be a string');
 
-        log.debug('createBucket', { bucketName, attributes });
+        log.debug('createBucket', { bucketName, attr: attributes });
         this._failover(0, 'POST', `/default/bucket/${bucketName}`, log,
                 attributes, callback);
     }


### PR DESCRIPTION
To be consistent across the projects, attributes is being renamed to attr.
