### PR TITLE
Remove all uses of encodeURIcomponent

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -160,7 +160,7 @@ class RESTClient {
         assert(typeof objName === 'string', 'objName must be a string');
         assert(typeof objVal === 'string', 'objVal must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += encodeURIComponent(objName);
+        path += querystring.escape(objName);
         log.debug('putObject', { bucketName, objName, val: objVal, path });
         this._failover(0, 'POST', path, log,
                        JSON.stringify({ data: objVal }), callback);
@@ -171,7 +171,7 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += encodeURIComponent(objName);
+        path += querystring.escape(objName);
 
         log.debug('getObject', { bucketName, objName, path });
         this._failover(0, 'GET', path, log, callback);
@@ -182,7 +182,7 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/parallel/${bucketName}/`;
-        path += encodeURIComponent(objName);
+        path += querystring.escape(objName);
         log.debug('GetBucketAndObject', {
             bucketName,
             objName,
@@ -196,7 +196,7 @@ class RESTClient {
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof objName === 'string', 'objName must be a string');
         let path = `/default/bucket/${bucketName}/`;
-        path += encodeURIComponent(objName);
+        path += querystring.escape(objName);
 
         log.debug('deleteObject', { bucketName, objName, path });
         this._failover(0, 'DELETE', path, log, callback);

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -3,10 +3,11 @@
 const errors = require('arsenal').errors;
 const assert = require('assert');
 const http = require('http');
+const querystring = require('querystring')
 const RESTClient = require('../../index.js').RESTClient;
-const existBucket = { 
+const existBucket = {
     name: 'Zaphod',
-    value: { status: 'alive' }, 
+    value: { status: 'alive' },
     raftInformation: {
             term: 1,
             cseq: 0,
@@ -132,5 +133,20 @@ describe('Unit tests with mockup server', function tests() {
             }
             done(new Error('Did not fail as expected'));
         });
+    });
+
+    it('expects that querystring.escape does not throw an error', done => {
+      if (querystring.escape('\uD800') && querystring.escape('\uD800')){
+        /* For a lone high or low surrogate querystring.escape does not throw
+        an error while encodeURIComponent throws an error
+        http://devdocs.io/javascript/global_objects/encodeuricomponent
+        */
+        // testing a lone high surrogate
+        assert.doesNotThrow(function(){querystring.escape('\uD800')})
+        // testing a lone low surrogate
+        assert.doesNotThrow(function(){querystring.escape('\uDFFF')})
+        return done();
+      }
+      done(new Error('Did not fail as expected'));
     });
 });


### PR DESCRIPTION
  encodeURIcomponent throws exceptions, so its replaced with queryString.escape. This change is made in parallel with issue #528 in IronMan-S3.