### PR TITLE
BF: map system errors to arsenal internal error

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -299,7 +299,11 @@ class RESTClient {
             }).on('error', next).on('end', () => {
                 this.endRespond(res, Buffer.concat(ret, retLen).toString(), log, next);
             });
-        }).on('error', next).end();
+        }).on('error', error => {
+            // covers system errors like ECONNREFUSED, ECONNRESET etc.
+            log.error('error sending request to metadata', { error });
+            next(errors.InternalError);
+        }).end();
     }
 }
 


### PR DESCRIPTION
This commit maps system errors like ECONNRESET, ECONNREFUSED to
be mapped to Arsenal's InternalError and logs the error to Werelogs
request logger.

Fix #67
