### PR TITLE
cleanup: remove bunyan-logstash dep. and unused config

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 const http = require('http');
 const querystring = require('querystring');
 
-const bunyanLogstash = require('bunyan-logstash');
 const Logger = require('werelogs');
 const shuffle = require('arsenal').shuffle;
 const conf = require('../config.json');
@@ -31,8 +30,6 @@ class RESTClient {
      * @param {object} loggingConfig an object with these keys:
      * @param {String} loggingConfig.logLevel
      * @param {String} loggingConfig.dumpLevel
-     * @param {String} loggingConfig.logstash.host
-     * @param {Number} loggingConfig.logstash.port
      *
      * @return {undefined}
      */
@@ -54,16 +51,6 @@ class RESTClient {
             options = {
                 level: config.logLevel,
                 dump: config.dumpLevel,
-                streams: [
-                    { stream: process.stdout},
-                    {
-                        type: 'raw',
-                        stream: bunyanLogstash.createStream({
-                            host: config.logstash.host,
-                            port: config.logstash.port,
-                        }),
-                    }
-                ],
             }
         }
         this.logging = new Logger('BucketClient', options);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "arsenal": "scality/Arsenal#rel/1.0",
-    "bunyan-logstash": "^0.3.4",
     "werelogs": "scality/werelogs#rel/1.0"
   }
 }


### PR DESCRIPTION
This commit removes bunyan-logstash dependency and it's config
that is no longer required by Werelogs.
