### PR TITLE
fix(bootstrap_list): add port parsing

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,5 @@
 {
   "bootstrap": [
-    "connectora.ringr2.devsca.com",
-    "connectorb.ringr2.devsca.com",
-    "connectorc.ringr2.devsca.com",
-    "connectord.ringr2.devsca.com",
-    "connectore.ringr2.devsca.com"
+      "bucketclient.testing.local:9000"
   ]
 }

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -1,13 +1,14 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('arsenal').errors;
 const assert = require('assert');
 const http = require('http');
 const https = require('https');
 const querystring = require('querystring');
 
 const Logger = require('werelogs').Logger;
+const errors = require('arsenal').errors;
 const shuffle = require('arsenal').shuffle;
+
 const conf = require('../config.json');
 
 function errorMap(mdError) {
@@ -21,6 +22,26 @@ function errorMap(mdError) {
         NotImplemented: 'NotImplemented',
     };
     return map[mdError] ? map[mdError] : mdError;
+}
+
+/**
+ * Turns the bootstrap list into an array of host/port objects.
+ *
+ * @param {String[]} list - the list to process
+ *
+ * @return {{ host: string, port: number }[]}
+ */
+function parseBootstrapList(list) {
+    return list.map(elem => {
+        const tmp = elem.split(':');
+        const host = tmp[0];
+        if (!tmp[1]) {
+            return { host, port: 9000 };
+        }
+        const port = Number.parseInt(tmp[1], 10);
+        assert.ok(!Number.isNaN(port), `port ${tmp[1]} is not a number`);
+        return { host, port };
+    });
 }
 
 class RESTClient {
@@ -39,12 +60,10 @@ class RESTClient {
      * @return {undefined}
      */
     constructor(bootstrap, loggingConfig, useHttps, key, cert, ca) {
-        this.bootstrap = bootstrap === undefined ?
-            conf.bootstrap : bootstrap;
+        this.bootstrap = parseBootstrapList(conf.bootstrap || bootstrap);
         assert(this.bootstrap instanceof Array, 'bootstrap must be an Array');
         this.bootstrap = shuffle(this.bootstrap);
         this.setCurrentBootstrap(this.bootstrap[0]);
-        this.port = 9000;
         this._useHttps = useHttps;
         this.transport = useHttps ? https : http;
         this._cert = cert;
@@ -95,11 +114,11 @@ class RESTClient {
     }
 
     getCurrentBootstrap() {
-        return this.current;
+        return this.current.host;
     }
 
     getPort() {
-        return this.port;
+        return this.current.port;
     }
 
     getRaftInformation(bucketName, reqUids, callback, reqLogger) {

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -10,6 +10,7 @@ const errors = require('arsenal').errors;
 const shuffle = require('arsenal').shuffle;
 
 const conf = require('../config.json');
+const parseBootstrapList = require('./bootstraplist').parseBootstrapList;
 
 function errorMap(mdError) {
     const map = {
@@ -22,26 +23,6 @@ function errorMap(mdError) {
         NotImplemented: 'NotImplemented',
     };
     return map[mdError] ? map[mdError] : mdError;
-}
-
-/**
- * Turns the bootstrap list into an array of host/port objects.
- *
- * @param {String[]} list - the list to process
- *
- * @return {{ host: string, port: number }[]}
- */
-function parseBootstrapList(list) {
-    return list.map(elem => {
-        const tmp = elem.split(':');
-        const host = tmp[0];
-        if (!tmp[1]) {
-            return { host, port: 9000 };
-        }
-        const port = Number.parseInt(tmp[1], 10);
-        assert.ok(!Number.isNaN(port), `port ${tmp[1]} is not a number`);
-        return { host, port };
-    });
 }
 
 class RESTClient {

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -41,7 +41,7 @@ class RESTClient {
      * @return {undefined}
      */
     constructor(bootstrap, loggingConfig, useHttps, key, cert, ca) {
-        this.bootstrap = parseBootstrapList(conf.bootstrap || bootstrap);
+        this.bootstrap = parseBootstrapList(bootstrap || conf.bootstrap);
         assert(this.bootstrap instanceof Array, 'bootstrap must be an Array');
         this.bootstrap = shuffle(this.bootstrap);
         this.setCurrentBootstrap(this.bootstrap[0]);

--- a/lib/bootstraplist.js
+++ b/lib/bootstraplist.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Turns the bootstrap list into an array of host/port objects.
+ *
+ * @param {String[]} list - the list to process
+ *
+ * @return {{ host: string, port: number }[]}
+ */
+function parseBootstrapList(list) {
+    return list.map(elem => {
+        const tmp = elem.split(':');
+        const host = tmp[0];
+        if (!tmp[1]) {
+            return { host, port: 9000 };
+        }
+        const port = Number.parseInt(tmp[1], 10);
+        assert.ok(!Number.isNaN(port), `port ${tmp[1]} is not a number`);
+        return { host, port };
+    });
+}
+
+module.exports = { parseBootstrapList };

--- a/lib/bootstraplist.js
+++ b/lib/bootstraplist.js
@@ -1,13 +1,17 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const assert = require('assert');
 
 /**
+ * @typedef {Object} BootstrapElement
+ * @prop {String} host - hostname of the element
+ * @prop {Number} port - port of the element
+ */
+
+/**
  * Turns the bootstrap list into an array of host/port objects.
- *
- * @param {String[]} list - the list to process
- *
- * @return {{ host: string, port: number }[]}
+ * @param {String[]} list       - the list to process
+ * @return {BootstrapElement[]} - array of host/port objects
  */
 function parseBootstrapList(list) {
     return list.map(elem => {

--- a/lib/bootstraplist.js
+++ b/lib/bootstraplist.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+
 /**
  * Turns the bootstrap list into an array of host/port objects.
  *

--- a/tests/unit/bootstrap.js
+++ b/tests/unit/bootstrap.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+
+const parse= require('../../lib/bootstraplist').parseBootstrapList;
+
+describe('Bootstrap list tests', () => {
+    const list = new Array(1024).fill(0)
+                                .map((item, index) => `localhost:${index}`);
+
+    it('should give back the right list for each member', () => {
+        parse(list).forEach((item, index) => {
+            assert.strictEqual(item.host, 'localhost');
+            assert.strictEqual(item.port, index);
+        });
+    })
+
+    it('should give back the right port', () => {
+        list.forEach((item, index) => {
+            assert.strictEqual(parse([item])[0].port, index);
+        });
+    });
+
+    it('should default to port 9000', () => {
+        parse(new Array(200).fill(0)
+                            .map((item, index) => `${index}`)
+        ).forEach((item, index) => {
+            assert.strictEqual(item.host, index.toString());
+            assert.strictEqual(item.port, 9000);
+        });
+    });
+});

--- a/tests/unit/bootstrap.js
+++ b/tests/unit/bootstrap.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const parse= require('../../lib/bootstraplist').parseBootstrapList;
+const parse = require('../../lib/bootstraplist').parseBootstrapList;
 
 describe('Bootstrap list tests', () => {
     const list = new Array(1024).fill(0)
@@ -11,7 +11,7 @@ describe('Bootstrap list tests', () => {
             assert.strictEqual(item.host, 'localhost');
             assert.strictEqual(item.port, index);
         });
-    })
+    });
 
     it('should give back the right port', () => {
         list.forEach((item, index) => {

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -1,11 +1,14 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('arsenal').errors;
 const assert = require('assert');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+
+const errors = require('arsenal').errors;
+
 const RESTClient = require('../../index.js').RESTClient;
+
 const existBucket = {
     name: 'Zaphod',
     value: { status: 'alive' },
@@ -37,12 +40,14 @@ const httpsOptions = {
 
 const env = {
     http: {
-        c: new RESTClient(['bucketclient.testing.local']),
+        c: new RESTClient(['bucketclient.testing.local:9000']),
         s: handler => http.createServer(handler),
     },
     https: {
         s: handler => https.createServer(httpsOptions, handler),
-        c: new RESTClient(['bucketclient.testing.local'], undefined, true,
+        c: new RESTClient(['bucketclient.testing.local:9000'],
+                          undefined,
+                          true,
                           httpsOptions.key,
                           httpsOptions.cert,
                           httpsOptions.ca[0]),


### PR DESCRIPTION
Enable the use of multiple `bucketd`s on a single host
