### PR TITLE
S3C-572: rest client to get logs of a raft session

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -17,6 +17,8 @@ function errorMap(mdError) {
         DBAlreadyExists: 'BucketAlreadyExists',
         ObjNotFound: 'NoSuchKey',
         NotImplemented: 'NotImplemented',
+        InvalidRange: 'InvalidRange',
+        BadRequest: 'BadRequest',
     };
     return map[mdError] ? map[mdError] : mdError;
 }

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -393,6 +393,55 @@ class RESTClient {
             callback(errors.InternalError);
         }).end();
     }
+
+    /**
+    *   send a request to get all raft sessions
+    *   get server's response and return it
+    *
+    *   @param {string} reqUids - the identifier of the request
+    *   @param {callback} callback - callback(err, info)
+    *   @param {werelogs.Logger} [reqLogger] - Logger instance
+    *   @return {undefined}
+    */
+    getAllRafts(reqUids, callback, reqLogger) {
+        const log = reqLogger || this.createLogger(reqUids);
+        const path = '/_/raft_sessions/';
+        log.debug('getting all raftSessions');
+        this.request('GET', path, log, null, null, callback);
+    }
+
+    /**
+    *   Get raft logs from bucketd
+    *   get server's response and return it
+    *
+    *   @param {string} raftId - raft session id
+    *   @param {number} [start=undefined] - starting sequence number. If it is
+    *       not given, its value will be 1
+    *   @param {number} [limit=undefined] - ending sequence number. If it is not
+    *       given, 10K entries is limited to be retrieved
+    *   @param {boolean} [targetLeader=undefined] - true: from leader instead of
+    *       follower
+    *   @param {string} reqUids - the identifier of the request
+    *   @param {callback} callback - callback(err, info)
+    *   @param {werelogs.Logger} [logger] - Logger instance
+    *   @return {undefined}
+    */
+    getRaftLog(raftId, start, limit, targetLeader, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        const path = `/_/raft_sessions/${raftId}/log`;
+        const query = {};
+        if (start !== undefined && start !== null) {
+            query.start_sequence = start;           // eslint-disable-line
+        }
+        if (limit !== undefined && limit !== null) {
+            query.end = limit;
+        }
+        if (targetLeader !== undefined && targetLeader !== null) {
+            query.targetLeader = targetLeader;
+        }
+        log.debug('getting raft log', { raftId, path, query });
+        this.request('GET', path, log, query, null, callback);
+    }
 }
 
 module.exports = RESTClient;


### PR DESCRIPTION
Raft session is given by its id {id}
Logs index is expectedly in a range [start, end], by default [1, 10000]
By default, logs are retrieved from a follower. A leader will be chosen if `targetLeader` is true.

Return a stringified object: { info: info-obj, log: logs-array} where

- info-obj contains stringified object { start, end, prune, cseq }
- logs-array is a stringified array containing logs whose indices are
from start to end, e.g. { value1, value2, .. }