### PR TITLE
get logs: change start_sequence to start

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -433,7 +433,7 @@ class RESTClient {
         const path = `/_/raft_sessions/${raftId}/log`;
         const query = {};
         if (start !== undefined && start !== null) {
-            query.start_sequence = start;           // eslint-disable-line
+            query.begin = start;
         }
         if (limit !== undefined && limit !== null) {
             query.end = limit;


### PR DESCRIPTION
Rename parameters of request's query:
`start_sequence` -> `begin`