### PR TITLE
ft: rename limit param to end

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -419,7 +419,7 @@ class RESTClient {
     *   @param {string} raftId - raft session id
     *   @param {number} [start=undefined] - starting sequence number. If it is
     *       not given, its value will be 1
-    *   @param {number} [limit=undefined] - ending sequence number. If it is not
+    *   @param {number} end=undefined] - ending sequence number. If it is not
     *       given, 10K entries is limited to be retrieved
     *   @param {boolean} [targetLeader=undefined] - true: from leader instead of
     *       follower
@@ -428,20 +428,15 @@ class RESTClient {
     *   @param {werelogs.Logger} [logger] - Logger instance
     *   @return {undefined}
     */
-    getRaftLog(raftId, start, limit, targetLeader, reqUids, callback, logger) {
+    getRaftLog(raftId, start, end, targetLeader, reqUids, callback, logger) {
         const log = logger || this.createLogger(reqUids);
         const path = `/_/raft_sessions/${raftId}/log`;
         const query = {};
-        const logStart = Number.isNaN(Number.parseInt(start, 10)) ?
-            0 : Number.parseInt(start, 10);
-        const logLimit = Number.isNaN(Number.parseInt(limit, 10)) ?
-            0 : Number.parseInt(limit, 10);
-        const logEnd = (logStart + logLimit) - 1;
         if (start !== undefined && start !== null) {
             query.begin = start;
         }
-        if (limit !== undefined && limit !== null) {
-            query.end = logEnd;
+        if (end !== undefined && end !== null) {
+            query.end = end;
         }
         if (targetLeader !== undefined && targetLeader !== null) {
             query.targetLeader = targetLeader;


### PR DESCRIPTION
This commit reverts changes from #112 and renames the param limit to
end set the right expectations.