### PR TITLE
Chore: update eslint modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/scality/bucketclient#readme",
   "devDependencies": {
-    "mocha": "",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.0",
+    "eslint": "4.6.0",
+    "eslint-config-airbnb-base": "12.0.0",
     "eslint-config-scality": "scality/Guidelines",
-    "eslint-plugin-react": "4.2.3"
+    "eslint-plugin-import": "2.7.0",
+    "mocha": "3.3.0"
   },
   "dependencies": {
     "arsenal": "scality/Arsenal",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "eslint": "4.6.0",
     "eslint-config-airbnb-base": "12.0.0",
-    "eslint-config-scality": "scality/Guidelines",
+    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
     "eslint-plugin-import": "2.7.0",
     "mocha": "3.3.0"
   },


### PR DESCRIPTION
Eslint upgrade will be in 2 steps:
- First add lint changes, drop package version changes and make sure new linter changes are compatible with the old eslint versions.
- Second, add this PR that has the version upgrades and merge after confirming first PR changes convert nicely

This should be merged after https://github.com/scality/bucketclient/pull/122