### PR TITLE
FT: ZENKO-267 Adding cloudserver routes for md ingestion

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -471,6 +471,22 @@ class RESTClient {
         log.debug('getting raft log', { raftId, path, query });
         this.requestStreamed('GET', path, log, query, null, callback);
     }
+
+    /**
+    *   Get list of buckets associated with raft session
+    *
+    *   @param {string} raftId - raft session id
+    *   @param {string} reqUids - the identifier of the request
+    *   @param {callback} callback - callback(err, stream)
+    *   @param {werelogs.Logger} [logger] - Logger instance
+    *   @return {undefined}
+    */
+    getRaftBuckets(raftId, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        const path = `/_/raft_sessions/${raftId}/bucket`;
+        log.debug('getting list of buckets for raft session', { raftId, path });
+        this.request('GET', path, log, null, null, callback);
+    }
 }
 
 module.exports = RESTClient;

--- a/tests/functional/client.js
+++ b/tests/functional/client.js
@@ -119,4 +119,15 @@ describe('Bucket Client tests', function testClient() {
             return undefined;
         });
     });
+
+    it('should get list of buckets from specified raft session', done => {
+        client.getRaftBuckets(1, null, (err, msg) => {
+            if (err) {
+                return done(err);
+            }
+            const bucketList = JSON.parse(msg);
+            assert.strictEqual(typeof bucketList, typeof []);
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
This PR allows getting bucket listing for each raft session, which is needed during the Ingestion process.