### PR TITLE
bugfix: MD-741 remove dependency on yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "arsenal": "scality/Arsenal#9f2e74e",
-    "werelogs": "scality/werelogs#4e0d97c",
-    "yarn": "^1.17.3"
+    "werelogs": "scality/werelogs#4e0d97c"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,11 +2466,6 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yarn@^1.17.3:
-  version "1.17.3"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.17.3.tgz#60e0b77d079eb78e753bb616f7592b51b6a9adce"
-  integrity sha512-CgA8o7nRZaQvmeF/WBx2FC7f9W/0X59T2IaLYqgMo6637wfp5mMEsM3YXoJtKUspnpmDJKl/gGFhnqS+sON7hA==
-
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
The dependency is not needed, hence remote it