### PR TITLE
INTEGRATION [PR#181 > development/8.1] build(deps-dev): bump eslint-plugin-react from 4.2.3 to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#71a059ad",
-    "eslint-plugin-react": "4.2.3"
+    "eslint-plugin-react": "4.3.0"
   },
   "dependencies": {
     "arsenal": "scality/Arsenal#9f2e74e",

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,10 +676,10 @@ eslint-config-scality@scality/Guidelines#71a059ad:
     commander "1.3.2"
     markdownlint "0.0.8"
 
-eslint-plugin-react@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-4.2.3.tgz#79aa0205b9cfe8c98f8747b04c7ee7d043be83df"
-  integrity sha1-eaoCBbnP6MmPh0ewTH7n0EO+g98=
+eslint-plugin-react@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz#c79aac8069d62de27887c13b8298d592088de378"
+  integrity sha1-x5qsgGnWLeJ4h8E7gpjVkgiN43g=
 
 eslint@^2.4.0:
   version "2.13.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #181.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/dependabot/npm_and_yarn/eslint-plugin-react-4.3.0`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/dependabot/npm_and_yarn/eslint-plugin-react-4.3.0
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/dependabot/npm_and_yarn/eslint-plugin-react-4.3.0
```

Please always comment pull request #181 instead of this one.