### PR TITLE
hotfix 7.8.0: S3C-3388 use constant httpClientFreeSocketTimeout

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -9,12 +9,7 @@ const HttpAgent = require('agentkeepalive');
 const HttpsAgent = require('agentkeepalive').HttpsAgent;
 
 const werelogs = require('werelogs');
-const errors = require('arsenal').errors;
-
-// bucketd server is configured to wait 60 seconds of inactivity on a
-// HTTP socket before closing it, so we might reuse it safely for a
-// little bit less time to avoid ECONNRESET issues
-const FREE_SOCKET_TIMEOUT = 55000;
+const { errors, constants } = require('arsenal');
 
 function errorMap(mdError) {
     const map = {
@@ -69,12 +64,12 @@ class RESTClient {
                 keepAlive: true,
                 ca: ca ? [ca] : undefined,
                 requestCert: true,
-                freeSocketTimeout: FREE_SOCKET_TIMEOUT,
+                freeSocketTimeout: constants.httpClientFreeSocketTimeout,
             });
         } else {
             this.agent = new HttpAgent({
                 keepAlive: true,
-                freeSocketTimeout: FREE_SOCKET_TIMEOUT,
+                freeSocketTimeout: constants.httpClientFreeSocketTimeout,
             });
         }
         this.setupLogging(logApi);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "agentkeepalive": "^4.1.3",
-    "arsenal": "scality/Arsenal#efdffd6",
+    "arsenal": "scality/Arsenal#918a1d7",
     "werelogs": "scality/werelogs#4e0d97c"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,15 +168,15 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-arsenal@scality/Arsenal#efdffd6:
+arsenal@scality/Arsenal#918a1d7:
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/efdffd6b99bc52445e93041d6c5cc93a0d541ffb"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/918a1d7c899a7ecddcd1d6e7bbdd49b5becc5bd0"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "6.12.2"
     async "~2.1.5"
-    debug "~2.3.3"
+    debug "~2.6.9"
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.9.1"
@@ -457,7 +457,7 @@ debug@3.2.6, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^2.1.1:
+debug@^2.1.1, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -470,13 +470,6 @@ debug@^4.1.0, debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  integrity sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=
-  dependencies:
-    ms "0.7.2"
 
 debug@~3.1.0:
   version "3.1.0"
@@ -1549,11 +1542,6 @@ mocha@:
     yargs "13.2.2"
     yargs-parser "13.0.0"
     yargs-unparser "1.5.0"
-
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Use the arsenal constant httpClientFreeSocketTimeout instead of a
hard-coded value in the HTTP client agent configuration.

(cherry picked from commit 876ce2651e9cacdd85c789c7f7ecb1b5c751b69f)