### PR TITLE
INTEGRATION [PR#219 > development/7.10] BKTCLT-1 update werelogs to a properly tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "agentkeepalive": "^4.1.3",
     "arsenal": "scality/Arsenal#918a1d7",
-    "werelogs": "scality/werelogs#4e0d97c"
+    "werelogs": "scality/werelogs#8.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,9 +2314,9 @@ werelogs@scality/werelogs#0ff7ec82:
   dependencies:
     safe-json-stringify "1.0.3"
 
-werelogs@scality/werelogs#4e0d97c:
-  version "7.4.1"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/4e0d97cf69ea7ed60bea90756278513e7e7ea9b1"
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #219.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/BKTCLT-1-use-tagged-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/BKTCLT-1-use-tagged-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/BKTCLT-1-use-tagged-werelogs
```

Please always comment pull request #219 instead of this one.