### PR TITLE
ft: BKTCLT-5 get bucket information

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -494,6 +494,24 @@ class RESTClient {
         log.debug('getting list of buckets for raft session', { raftId, path });
         this.request('GET', path, log, null, null, callback);
     }
+
+    /**
+    *   Get proper bucket information like raftSessionId or other statuses
+    *
+    *   @param {string} bucketName - bucketName
+    *   @param {string} reqUids - the identifier of the request
+    *   @param {callback} callback - callback(err, stream)
+    *   @param {werelogs.Logger} [logger] - Logger instance
+    *   @return {undefined}
+    */
+    getBucketInformation(bucketName, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        assert(typeof bucketName === 'string', 'bucketName must be a string');
+
+        log.debug('getBucketInformation', { bucketName });
+        this.request('GET', `/_/buckets/${bucketName}`, log,
+            null, null, callback);
+    }
 }
 
 module.exports = RESTClient;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Bucket Client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -20,6 +20,16 @@ const existBucket = {
         ip: '127.0.0.1',
         port: 4242,
     },
+    bucketInformation: {
+        raftSessionId: 3,
+        creating: false,
+        deleting: false,
+        version: 0,
+        leader: {
+            host: '127.0.0.4',
+            port: 4500,
+        },
+    },
 };
 const nonExistBucket = { name: 'Ford' };
 const reqUids = 'REQ1';
@@ -70,6 +80,9 @@ function handler(req, res) {
         } else if (req.url === `/default/informations/${existBucket.name}`) {
             makeResponse(res, 200, 'OK');
             return res.end(JSON.stringify(existBucket.raftInformation));
+        } else if (req.url === `/_/buckets/${existBucket.name}`) {
+            makeResponse(res, 200, 'OK');
+            return res.end(JSON.stringify(existBucket.bucketInformation));
         } else if (req.url === '/_/healthcheck') {
             makeResponse(res, 200, 'OK');
         } else {
@@ -137,6 +150,25 @@ Object.keys(env).forEach(key => {
         });
 
         it('should get Raft informations on an unexisting bucket', done => {
+            client.getRaftInformation(nonExistBucket.name, reqUids,
+                err => {
+                    const error = errors.NoSuchBucket;
+                    error.isExpected = true;
+                    assert.deepStrictEqual(err, error);
+                    return done();
+                });
+        });
+
+        it('should get Bucket informations on an existing bucket', done => {
+            client.getBucketInformation(existBucket.name, reqUids,
+                (err, data) => {
+                    const ret = JSON.parse(data);
+                    assert.deepStrictEqual(ret, existBucket.bucketInformation);
+                    done(err);
+                });
+        });
+
+        it('should get Bucket informations on an unexisting bucket', done => {
             client.getRaftInformation(nonExistBucket.name, reqUids,
                 err => {
                     const error = errors.NoSuchBucket;


### PR DESCRIPTION
There is currently no routine to exacly get the raft session ID
from the bucket name. It is possible to use getRaftInformations()
but it contains the state of the repd servers which contains the
raft ID so this is not very clear.