### PR TITLE
BKTCLT-19 new bindings for raft session admin routes

### DIFF
--- a/go/admin_getbucketsessionid.go
+++ b/go/admin_getbucketsessionid.go
@@ -1,0 +1,26 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// AdminGetBucketSessionID returns the raft session ID of the given bucket.
+// Returns -1 and an error if the bucket doesn't exist, or if a request error occurs.
+func (client *BucketClient) AdminGetBucketSessionID(ctx context.Context, bucketName string) (int, error) {
+	resource := fmt.Sprintf("/_/buckets/%s/id", bucketName)
+	responseBody, err := client.Request(ctx, "AdminGetBucketSessionID", "GET", resource)
+	if err != nil {
+		return 0, err
+	}
+	sessionId, err := strconv.ParseInt(string(responseBody), 10, 0)
+	if err != nil {
+		return 0, &BucketClientError{
+			"AdminGetBucketSessionID", "GET", client.Endpoint, resource, 0, "",
+			fmt.Errorf("bucketd did not return a valid session ID in response body: '%s'",
+				string(responseBody)),
+		}
+	}
+	return int(sessionId), nil
+}

--- a/go/admin_getbucketsessionid_test.go
+++ b/go/admin_getbucketsessionid_test.go
@@ -1,0 +1,26 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+)
+
+var _ = Describe("AdminGetBucketSessionId()", func() {
+	It("return the raft session ID hosting a bucket", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/my-bucket/id",
+			httpmock.NewStringResponder(200, "42"),
+		)
+		Expect(client.AdminGetBucketSessionID(ctx, "my-bucket")).To(Equal(42))
+	})
+	It("return an error if the bucket doesn't exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/nosuchbucket/id",
+			httpmock.NewStringResponder(404, ""),
+		)
+		_, err := client.AdminGetBucketSessionID(ctx, "nosuchbucket")
+		Expect(err).To(MatchError(ContainSubstring("bucketd returned HTTP status 404")))
+	})
+})

--- a/go/admin_getsessioninfo.go
+++ b/go/admin_getsessioninfo.go
@@ -1,0 +1,51 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AdminGetAllSessionsInfo returns raft session info for all Metadata
+// raft sessions available on the S3C deployment.
+func (client *BucketClient) AdminGetAllSessionsInfo(ctx context.Context) ([]SessionInfo, error) {
+	responseBody, err := client.Request(ctx, "AdminGetAllSessionsInfo", "GET", "/_/raft_sessions")
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedInfo []SessionInfo
+	jsonErr := json.Unmarshal(responseBody, &parsedInfo)
+	if jsonErr != nil {
+		return nil, ErrorMalformedResponse("AdminGetAllSessionsInfo",
+			"GET", client.Endpoint, "/_/raft_sessions", jsonErr)
+	}
+	return parsedInfo, nil
+}
+
+// AdminGetSessionInfo returns raft session info for the given raft session ID.
+// Returns nil and an error if the raft session doesn't exist, or if a request
+// error occurs.
+func (client *BucketClient) AdminGetSessionInfo(ctx context.Context,
+	sessionId int) (*SessionInfo, error) {
+	// When querying /_/raft_sessions/X/info, bucketd returns a
+	// status 500 if the raft session doesn't exist, which is hard
+	// to distinguish from a generic type of failure. For this
+	// reason, instead, we fetch the info for all raft sessions
+	// then lookup the one we want.
+	sessionsInfo, err := client.AdminGetAllSessionsInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, sessionInfo := range sessionsInfo {
+		if sessionInfo.ID == sessionId {
+			return &sessionInfo, nil
+		}
+	}
+	// raft session does not exist: return a 404 status as if coming from bucketd
+	return nil, &BucketClientError{
+		"AdminGetSessionInfo", "GET", client.Endpoint, "/_/raft_sessions",
+		404, "RaftSessionNotFound",
+		fmt.Errorf("no such raft session: %d", sessionId),
+	}
+}

--- a/go/admin_getsessioninfo_test.go
+++ b/go/admin_getsessioninfo_test.go
@@ -1,0 +1,122 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var testAdminGetAllSessionsInfoBucketdResponse = `[
+  {
+    "id": 1,
+    "raftMembers": [
+      {
+        "id": 10,
+        "name": "md1-cluster1",
+        "display_name": "127.0.0.1 (md1-cluster1)",
+        "host": "127.0.0.1",
+        "port": 4201,
+        "adminPort": 4251,
+        "mdClusterId": "1"
+      }
+    ],
+    "connectedToLeader": true
+  },
+  {
+    "id": 2,
+    "raftMembers": [
+      {
+        "id": 20,
+        "name": "md1-cluster1",
+        "display_name": "127.0.0.1 (md1-cluster1)",
+        "host": "127.0.0.1",
+        "port": 4202,
+        "adminPort": 4252,
+        "mdClusterId": "1"
+      }
+    ],
+    "connectedToLeader": false
+  }
+]
+`
+
+var _ = Describe("AdminGetSessionInfo()/AdminGetAllSessionsInfo()", func() {
+	Describe("AdminGetAllSessionsInfo()", func() {
+		It("return info about all raft sessions", func(ctx SpecContext) {
+			httpmock.RegisterResponder(
+				"GET", "http://localhost:9000/_/raft_sessions",
+				httpmock.NewStringResponder(200, testAdminGetAllSessionsInfoBucketdResponse),
+			)
+			Expect(client.AdminGetAllSessionsInfo(ctx)).To(Equal([]bucketclient.SessionInfo{
+				{
+					ID: 1,
+					RaftMembers: []bucketclient.MemberInfo{
+						{
+							ID:          10,
+							Name:        "md1-cluster1",
+							DisplayName: "127.0.0.1 (md1-cluster1)",
+							Host:        "127.0.0.1",
+							Port:        4201,
+							AdminPort:   4251,
+							MDClusterId: "1",
+						},
+					},
+					ConnectedToLeader: true,
+				},
+				{
+					ID: 2,
+					RaftMembers: []bucketclient.MemberInfo{
+						{
+							ID:          20,
+							Name:        "md1-cluster1",
+							DisplayName: "127.0.0.1 (md1-cluster1)",
+							Host:        "127.0.0.1",
+							Port:        4202,
+							AdminPort:   4252,
+							MDClusterId: "1",
+						},
+					},
+					ConnectedToLeader: false,
+				},
+			}))
+		})
+	})
+
+	Describe("AdminGetSessionInfo()", func() {
+		It("return info about a particular raft session", func(ctx SpecContext) {
+			httpmock.RegisterResponder(
+				"GET", "http://localhost:9000/_/raft_sessions",
+				httpmock.NewStringResponder(200, testAdminGetAllSessionsInfoBucketdResponse),
+			)
+			Expect(client.AdminGetSessionInfo(ctx, 2)).To(Equal(&bucketclient.SessionInfo{
+				ID: 2,
+				RaftMembers: []bucketclient.MemberInfo{
+					{
+						ID:          20,
+						Name:        "md1-cluster1",
+						DisplayName: "127.0.0.1 (md1-cluster1)",
+						Host:        "127.0.0.1",
+						Port:        4202,
+						AdminPort:   4252,
+						MDClusterId: "1",
+					},
+				},
+				ConnectedToLeader: false,
+			}))
+		})
+		It("return an error if the session doesn't exist", func(ctx SpecContext) {
+			httpmock.RegisterResponder(
+				"GET", "http://localhost:9000/_/raft_sessions",
+				httpmock.NewStringResponder(200, testAdminGetAllSessionsInfoBucketdResponse),
+			)
+			_, err := client.AdminGetSessionInfo(ctx, 3)
+			bcErr, ok := err.(*bucketclient.BucketClientError)
+			Expect(ok).To(BeTrue())
+			Expect(bcErr.StatusCode).To(Equal(404))
+			Expect(bcErr.ErrorType).To(Equal("RaftSessionNotFound"))
+		})
+	})
+})

--- a/go/admin_getsessionleader.go
+++ b/go/admin_getsessionleader.go
@@ -1,0 +1,29 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AdminGetSessionLeader returns the member info for the leader of the
+// given raft session ID.
+
+// Returns nil and an error if the raft session doesn't exist, if
+// bucketd is not connected to the leader, or if a request error
+// occurs.
+func (client *BucketClient) AdminGetSessionLeader(ctx context.Context, sessionId int) (*MemberInfo, error) {
+	resource := fmt.Sprintf("/_/raft_sessions/%d/leader", sessionId)
+	responseBody, err := client.Request(ctx, "AdminGetSessionLeader", "GET", resource)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedInfo MemberInfo
+	jsonErr := json.Unmarshal(responseBody, &parsedInfo)
+	if jsonErr != nil {
+		return nil, ErrorMalformedResponse("AdminGetSessionLeader",
+			"GET", client.Endpoint, resource, jsonErr)
+	}
+	return &parsedInfo, nil
+}

--- a/go/admin_getsessionleader_test.go
+++ b/go/admin_getsessionleader_test.go
@@ -1,0 +1,48 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var testAdminGetSessionLeaderBucketdResponse = `{
+  "id": 10,
+  "name": "md1-cluster1",
+  "display_name": "127.0.0.1 (md1-cluster1)",
+  "host": "127.0.0.1",
+  "port": 4201,
+  "adminPort": 4251,
+  "mdClusterId": "1"
+}
+`
+
+var _ = Describe("AdminGetSessionLeader()", func() {
+	It("returns a MemberInfo about the leader of a raft session", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/raft_sessions/3/leader",
+			httpmock.NewStringResponder(200, testAdminGetSessionLeaderBucketdResponse),
+		)
+		Expect(client.AdminGetSessionLeader(ctx, 3)).To(Equal(&bucketclient.MemberInfo{
+			ID:          10,
+			Name:        "md1-cluster1",
+			DisplayName: "127.0.0.1 (md1-cluster1)",
+			Host:        "127.0.0.1",
+			Port:        4201,
+			AdminPort:   4251,
+			MDClusterId: "1",
+		}))
+	})
+
+	It("forwards an error from bucketd", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/raft_sessions/3/leader",
+			httpmock.NewStringResponder(400, ""),
+		)
+		_, err := client.AdminGetSessionLeader(ctx, 3)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/go/admin_types.go
+++ b/go/admin_types.go
@@ -1,0 +1,17 @@
+package bucketclient
+
+type MemberInfo struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	AdminPort   int    `json:"adminPort"`
+	MDClusterId string `json:"mdClusterId"`
+}
+
+type SessionInfo struct {
+	ID                int          `json:"id"`
+	RaftMembers       []MemberInfo `json:"raftMembers"`
+	ConnectedToLeader bool         `json:"connectedToLeader"`
+}

--- a/go/bucketclient_suite_test.go
+++ b/go/bucketclient_suite_test.go
@@ -3,11 +3,29 @@ package bucketclient_test
 import (
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/scality/bucketclient/go"
 )
 
 func TestBucketclient(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Bucketclient Suite")
 }
+
+var client *bucketclient.BucketClient
+
+var _ = BeforeSuite(func() {
+	httpmock.Activate()
+	client = bucketclient.New("http://localhost:9000")
+})
+
+var _ = AfterSuite(func() {
+	httpmock.DeactivateAndReset()
+})
+
+var _ = AfterEach(func() {
+	httpmock.Reset()
+})

--- a/go/bucketclientrequest_test.go
+++ b/go/bucketclientrequest_test.go
@@ -25,25 +25,16 @@ func (rc *shortReadCloser) Close() error {
 }
 
 var _ = Describe("BucketClient.Request()", func() {
-	BeforeEach(func() {
-		httpmock.Reset()
-	})
-
 	It("with invalid URL", func(ctx SpecContext) {
+		// Here we do a basic test checking that errors from
+		// the connection layer are forwarded correctly, "no
+		// responder found" is the error returned by httpmock
 		invalidClient := bucketclient.New("http://invalid:9000")
 		_, err := invalidClient.Request(ctx, "GetSomething", "GET", "/foo/bar")
-		Expect(err).To(MatchError(ContainSubstring("no such host")))
+		Expect(err).To(MatchError(ContainSubstring("no responder found")))
 	})
 
 	Context("with valid URL", Ordered, func() {
-		var client *bucketclient.BucketClient
-		BeforeAll(func() {
-			httpmock.Activate()
-			client = bucketclient.New("http://localhost:9000")
-		})
-		AfterAll(func() {
-			defer httpmock.DeactivateAndReset()
-		})
 		It("succeeds with a 200 response on GET request", func(ctx SpecContext) {
 			httpmock.RegisterResponder(
 				"GET", "http://localhost:9000/default/bucket/somebucket/someobject",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.8",
+  "version": "7.10.9",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Add two new functions binding the admin routes:

- AdminGetBucketSessionID (`GET /_/buckets/my-bucket/id`)

- AdminGetSessionInfo/AdminGetAllSessionsInfo (`GET /_/raft_sessions`)

- AdminGetSessionLeader() (`GET /_/raft_sessions/X/leader`)