### PR TITLE
ft: BKTCLT-23 implement PostBatch Go binding

### DIFF
--- a/go/postbatch.go
+++ b/go/postbatch.go
@@ -1,0 +1,35 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type PostBatchEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+func (client *BucketClient) PostBatch(ctx context.Context,
+	bucketName string, batch []PostBatchEntry) error {
+	resource := fmt.Sprintf("/default/batch/%s", bucketName)
+	postPayload := struct {
+		Batch []PostBatchEntry `json:"batch"`
+	}{Batch: batch}
+	postBody, err := json.Marshal(postPayload)
+	if err != nil {
+		return &BucketClientError{
+			"PostBatch", "POST", client.Endpoint, resource, 0, "",
+			fmt.Errorf("error marshaling POST request body: %w", err),
+		}
+	}
+	_, err = client.Request(ctx, "PostBatch", "POST", resource,
+		RequestBodyOption(postBody),
+		RequestBodyContentTypeOption("application/json"),
+		// Because we write a batch of low-level entries directly to
+		// the database, the request is idempotent.
+		RequestIdempotent)
+	return err
+}

--- a/go/postbatch_test.go
+++ b/go/postbatch_test.go
@@ -1,0 +1,36 @@
+package bucketclient_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"io"
+	"net/http"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("PostBatch()", func() {
+	It("POSTs a batch to bucketd", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"POST", "http://localhost:9000/default/batch/somebucket",
+			func(req *http.Request) (*http.Response, error) {
+				defer req.Body.Close()
+				Expect(io.ReadAll(req.Body)).To(Equal(
+					[]byte(`{"batch":[{"key":"foo","value":"{}"},{"key":"bar","type":"del"}]}`)))
+
+				contentType, hasHeader := req.Header["Content-Type"]
+				Expect(hasHeader).To(BeTrue())
+				Expect(contentType).To(Equal([]string{"application/json"}))
+
+				return httpmock.NewStringResponse(200, "got it"), nil
+			},
+		)
+
+		Expect(client.PostBatch(ctx, "somebucket", []bucketclient.PostBatchEntry{
+			{Key: "foo", Value: "{}"},
+			{Key: "bar", Type: "del"},
+		})).To(Succeed())
+	})
+})


### PR DESCRIPTION
Add PostBatch to the Go client bindings, to write a batch to bucketd via the `POST /default/batch/bucket` route.