### PR TITLE
ft: BKTCLT-25 go client: implement AdminGetSessionLog()

### DIFF
--- a/go/admin_getsessionlog.go
+++ b/go/admin_getsessionlog.go
@@ -1,0 +1,37 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type AdminGetSessionLogResponse struct {
+	Info SessionLogInfo     `json:"info"`
+	Log  []SessionLogRecord `json:"log"`
+}
+
+// AdminGetSessionLog returns a range of Raft oplog from the given raft session.
+// sessionId is the raft session ID
+// beginSeq is the first raft sequence number to fetch
+// nRecords is the maximum number of records to fetch starting from beginSeq
+// if targetLeader is true, it fetches the oplog from the leader,
+// otherwise fetches from one of the followers
+func (client *BucketClient) AdminGetSessionLog(ctx context.Context,
+	sessionId int, beginSeq int64, nRecords int, targetLeader bool) (*AdminGetSessionLogResponse, error) {
+	resource := fmt.Sprintf("/_/raft_sessions/%d/log?begin=%d&limit=%d", sessionId, beginSeq, nRecords)
+	if targetLeader {
+		resource += "&target_leader=true"
+	}
+	responseBody, err := client.Request(ctx, "AdminGetSessionLog", "GET", resource)
+	if err != nil {
+		return nil, err
+	}
+	var parsedResponse AdminGetSessionLogResponse
+	jsonErr := json.Unmarshal(responseBody, &parsedResponse)
+	if jsonErr != nil {
+		return nil, ErrorMalformedResponse("AdminGetSessionsLog",
+			"GET", client.Endpoint, resource, jsonErr)
+	}
+	return &parsedResponse, nil
+}

--- a/go/admin_getsessionlog_test.go
+++ b/go/admin_getsessionlog_test.go
@@ -1,0 +1,101 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"net/http"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("AdminGetSessionLog()", func() {
+	It("returns a range of raft oplog", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/raft_sessions/2/log?begin=10&limit=2",
+			httpmock.NewStringResponder(200, `{
+  "info": {
+    "start": 10,
+    "cseq": 100,
+    "prune": 1
+  },
+  "log": [
+    {
+      "db": "bucket1",
+      "method": 8,
+      "entries": [
+        {
+          "key": "key1",
+          "value": "{\"foo\":\"bar\"}"
+        },
+        {
+          "key": "key2",
+          "type": "del"
+        }
+      ]
+    },
+    {
+      "db": "bucket2",
+      "method": 0,
+      "entries": [
+        {
+          "value": "{}"
+        }
+      ]
+    }
+  ]
+}
+`),
+		)
+		Expect(
+			client.AdminGetSessionLog(ctx, 2, 10, 2, false),
+		).To(Equal(&bucketclient.AdminGetSessionLogResponse{
+			Info: bucketclient.SessionLogInfo{
+				Start: 10,
+				CSeq:  100,
+				Prune: 1,
+			},
+			Log: []bucketclient.SessionLogRecord{
+				bucketclient.SessionLogRecord{
+					Bucket:    "bucket1",
+					DBMethod:  bucketclient.DBMethodBatch,
+					Timestamp: "",
+					Entries: []bucketclient.SessionLogEntry{
+						bucketclient.SessionLogEntry{
+							Key:   "key1",
+							Value: "{\"foo\":\"bar\"}",
+							Type:  "",
+						},
+						bucketclient.SessionLogEntry{
+							Key:   "key2",
+							Value: "",
+							Type:  "del",
+						},
+					},
+				},
+				bucketclient.SessionLogRecord{
+					Bucket:    "bucket2",
+					DBMethod:  bucketclient.DBMethodCreate,
+					Timestamp: "",
+					Entries: []bucketclient.SessionLogEntry{
+						bucketclient.SessionLogEntry{Key: "", Value: "{}", Type: ""},
+					},
+				},
+			},
+		}))
+	})
+
+	It("returns an error with status 416 RequestedRangeNotSatisfiable", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/raft_sessions/2/log?begin=10&limit=2",
+			httpmock.NewStringResponder(http.StatusRequestedRangeNotSatisfiable, ""),
+		)
+		_, err := client.AdminGetSessionLog(ctx, 2, 10, 2, false)
+		Expect(err).To(HaveOccurred())
+		bcErr, ok := err.(*bucketclient.BucketClientError)
+		Expect(ok).To(BeTrue())
+		Expect(bcErr.StatusCode).To(Equal(http.StatusRequestedRangeNotSatisfiable))
+	})
+})

--- a/go/admin_types.go
+++ b/go/admin_types.go
@@ -15,3 +15,22 @@ type SessionInfo struct {
 	RaftMembers       []MemberInfo `json:"raftMembers"`
 	ConnectedToLeader bool         `json:"connectedToLeader"`
 }
+
+type SessionLogInfo struct {
+	Start int64 `json:"start"`
+	CSeq  int64 `json:"cseq"`
+	Prune int64 `json:"prune"`
+}
+
+type SessionLogRecord struct {
+	Bucket    string            `json:"db"`
+	DBMethod  DBMethodType      `json:"method"`
+	Timestamp string            `json:"timestamp,omitempty"`
+	Entries   []SessionLogEntry `json:"entries"`
+}
+
+type SessionLogEntry struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+	Type  string `json:"type,omitempty"`
+}

--- a/go/constants.go
+++ b/go/constants.go
@@ -1,0 +1,16 @@
+package bucketclient
+
+type DBMethodType int
+
+const (
+	DBMethodCreate        DBMethodType = 0
+	DBMethodDelete        DBMethodType = 1
+	DBMethodGet           DBMethodType = 2
+	DBMethodPut           DBMethodType = 3
+	DBMethodList          DBMethodType = 4
+	DBMethodDel           DBMethodType = 5
+	DBMethodGetAttributes DBMethodType = 6
+	DBMethodPutAttributes DBMethodType = 7
+	DBMethodBatch         DBMethodType = 8
+	DBMethodNoop          DBMethodType = 9
+)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.10",
+  "version": "7.10.11",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Implement the admin route `GET /_/raft_sessions/x/log` to retrieve a range of log