### PR TITLE
ft: BKTCLT-26 go client: bucket access mode

### DIFF
--- a/go/admin_getbucketaccessmode.go
+++ b/go/admin_getbucketaccessmode.go
@@ -1,0 +1,24 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// AdminGetBucketAccessMode returns the access mode of the given bucket:
+// - "read-write" when the bucket is accessible for reading and writing (default)
+// - "read-only" when the bucket is only accessible for read operations.
+// Returns "" and an error if the bucket doesn't exist, or if a request error occurs.
+func (client *BucketClient) AdminGetBucketAccessMode(ctx context.Context,
+	bucketName string) (BucketAccessMode, error) {
+	// Escape the bucket name to avoid any risk to inadvertently or maliciously
+	// call another route with an incorrect/crafted bucket name containing slashes.
+	resource := fmt.Sprintf("/_/buckets/%s/accessMode", url.PathEscape(bucketName))
+	responseBody, err := client.Request(ctx, "AdminGetBucketAccessMode", "GET", resource)
+	if err != nil {
+		return "", err
+	}
+	accessMode := BucketAccessMode(string(responseBody))
+	return accessMode, nil
+}

--- a/go/admin_getbucketaccessmode_test.go
+++ b/go/admin_getbucketaccessmode_test.go
@@ -1,0 +1,37 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("AdminGetBucketAccessMode()", func() {
+	It("return the access mode of the bucket", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/my-bucket/accessMode",
+			httpmock.NewStringResponder(200, "read-only"),
+		)
+		Expect(client.AdminGetBucketAccessMode(ctx, "my-bucket")).To(
+			Equal(bucketclient.BucketAccessModeReadOnly))
+	})
+	It("return an error if the bucket doesn't exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/nosuchbucket/accessMode",
+			httpmock.NewStringResponder(404, ""),
+		)
+		_, err := client.AdminGetBucketAccessMode(ctx, "nosuchbucket")
+		Expect(err).To(MatchError(ContainSubstring("bucketd returned HTTP status 404")))
+	})
+	It("escapes a bucket name containing slashes", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/my-bucket%2Fwith-a-slash/accessMode",
+			httpmock.NewStringResponder(200, "read-only"),
+		)
+		Expect(client.AdminGetBucketAccessMode(ctx, "my-bucket/with-a-slash")).To(
+			Equal(bucketclient.BucketAccessModeReadOnly))
+	})
+})

--- a/go/admin_getbucketsessionid.go
+++ b/go/admin_getbucketsessionid.go
@@ -3,13 +3,16 @@ package bucketclient
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 )
 
 // AdminGetBucketSessionID returns the raft session ID of the given bucket.
-// Returns -1 and an error if the bucket doesn't exist, or if a request error occurs.
+// Returns 0 and an error if the bucket doesn't exist, or if a request error occurs.
 func (client *BucketClient) AdminGetBucketSessionID(ctx context.Context, bucketName string) (int, error) {
-	resource := fmt.Sprintf("/_/buckets/%s/id", bucketName)
+	// Escape the bucket name to avoid any risk to inadvertently or maliciously
+	// call another route with an incorrect/crafted bucket name containing slashes.
+	resource := fmt.Sprintf("/_/buckets/%s/id", url.PathEscape(bucketName))
 	responseBody, err := client.Request(ctx, "AdminGetBucketSessionID", "GET", resource)
 	if err != nil {
 		return 0, err

--- a/go/admin_getbucketsessionid_test.go
+++ b/go/admin_getbucketsessionid_test.go
@@ -23,4 +23,11 @@ var _ = Describe("AdminGetBucketSessionId()", func() {
 		_, err := client.AdminGetBucketSessionID(ctx, "nosuchbucket")
 		Expect(err).To(MatchError(ContainSubstring("bucketd returned HTTP status 404")))
 	})
+	It("escapes a bucket name containing slashes", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "http://localhost:9000/_/buckets/my-bucket%2Fwith-a-slash/id",
+			httpmock.NewStringResponder(200, "42"),
+		)
+		Expect(client.AdminGetBucketSessionID(ctx, "my-bucket/with-a-slash")).To(Equal(42))
+	})
 })

--- a/go/admin_setbucketaccessmode.go
+++ b/go/admin_setbucketaccessmode.go
@@ -1,0 +1,21 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// AdminSetBucketAccessMode sets the access mode of the given bucket:
+//   - "read-write" to restore the default read/write access
+//   - "read-only" to set the bucket in read-only mode and refuse write
+//     operations with a 503 ServiceUnavailable error.
+//
+// Returns an error if the bucket doesn't exist, or if a request error occurs.
+func (client *BucketClient) AdminSetBucketAccessMode(ctx context.Context,
+	bucketName string, accessMode BucketAccessMode) error {
+	resource := fmt.Sprintf("/_/buckets/%s/accessMode?mode=%s",
+		url.PathEscape(bucketName), accessMode)
+	_, err := client.Request(ctx, "AdminSetBucketAccessMode", "PUT", resource)
+	return err
+}

--- a/go/admin_setbucketaccessmode_test.go
+++ b/go/admin_setbucketaccessmode_test.go
@@ -1,0 +1,38 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("AdminSetBucketAccessMode()", func() {
+	It("sets the access mode of the bucket", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"PUT", "http://localhost:9000/_/buckets/my-bucket/accessMode?mode=read-only",
+			httpmock.NewStringResponder(200, ""),
+		)
+		Expect(client.AdminSetBucketAccessMode(ctx,
+			"my-bucket", bucketclient.BucketAccessModeReadOnly)).To(Succeed())
+	})
+	It("return an error if the bucket doesn't exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"PUT", "http://localhost:9000/_/buckets/nosuchbucket/accessMode?mode=read-only",
+			httpmock.NewStringResponder(404, ""),
+		)
+		err := client.AdminSetBucketAccessMode(ctx,
+			"nosuchbucket", bucketclient.BucketAccessModeReadOnly)
+		Expect(err).To(MatchError(ContainSubstring("bucketd returned HTTP status 404")))
+	})
+	It("escapes a bucket name containing slashes", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"PUT", "http://localhost:9000/_/buckets/my-bucket%2Fwith-a-slash/accessMode?mode=read-only",
+			httpmock.NewStringResponder(200, ""),
+		)
+		Expect(client.AdminSetBucketAccessMode(ctx,
+			"my-bucket/with-a-slash", bucketclient.BucketAccessModeReadOnly)).To(Succeed())
+	})
+})

--- a/go/admin_types.go
+++ b/go/admin_types.go
@@ -34,3 +34,10 @@ type SessionLogEntry struct {
 	Value string `json:"value,omitempty"`
 	Type  string `json:"type,omitempty"`
 }
+
+type BucketAccessMode string
+
+const (
+	BucketAccessModeReadWrite BucketAccessMode = "read-write"
+	BucketAccessModeReadOnly  BucketAccessMode = "read-only"
+)


### PR DESCRIPTION
Implement the bucket access mode getter and setter API functions.