### PR TITLE
ft: BKTCLT-27 Go client: implement PutBucketAttributes

### DIFF
--- a/go/putbucketattributes.go
+++ b/go/putbucketattributes.go
@@ -1,0 +1,16 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// PutBucketAttributes updates the bucket attributes with a new JSON blob.
+func (client *BucketClient) PutBucketAttributes(ctx context.Context, bucketName string,
+	bucketAttributes []byte) error {
+	resource := fmt.Sprintf("/default/attributes/%s", url.PathEscape(bucketName))
+	_, err := client.Request(ctx, "PutBucketAttributes", "POST", resource,
+		RequestBodyOption(bucketAttributes))
+	return err
+}

--- a/go/putbucketattributes_test.go
+++ b/go/putbucketattributes_test.go
@@ -1,0 +1,25 @@
+package bucketclient_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"io"
+	"net/http"
+)
+
+var _ = Describe("PutBucketAttributes()", func() {
+	It("updates bucket attributes with a new JSON blob", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"POST", "/default/attributes/my-bucket",
+			func(req *http.Request) (*http.Response, error) {
+				defer req.Body.Close()
+				Expect(io.ReadAll(req.Body)).To(Equal([]byte(`{"foo":"bar"}`)))
+				return httpmock.NewStringResponse(200, ""), nil
+			},
+		)
+		Expect(client.PutBucketAttributes(ctx,
+			"my-bucket", []byte(`{"foo":"bar"}`))).To(Succeed())
+	})
+})


### PR DESCRIPTION
Implement the bucketd route to put bucket attributes: `POST /default/attributes/bucketname`