### PR TITLE
ft: BKTCLT-28 go client: metastore entry get/put/delete API

### DIFF
--- a/go/createmetastoreentry.go
+++ b/go/createmetastoreentry.go
@@ -1,0 +1,23 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// CreateMetastoreEntry creates or updates a metastore entry for the given bucket
+func (client *BucketClient) CreateMetastoreEntry(ctx context.Context, bucketName string,
+	metastoreEntry MetastoreEntry) error {
+	resource := fmt.Sprintf("/default/metastore/db/%s", bucketName)
+	postBody, err := json.Marshal(metastoreEntry)
+	if err != nil {
+		return &BucketClientError{
+			"CreateMetastoreEntry", "POST", client.Endpoint, resource, 0, "",
+			fmt.Errorf("error marshaling POST request body: %w", err),
+		}
+	}
+	_, err = client.Request(ctx, "CreateMetastoreEntry", "POST", resource,
+		RequestBodyOption(postBody))
+	return err
+}

--- a/go/createmetastoreentry_test.go
+++ b/go/createmetastoreentry_test.go
@@ -1,0 +1,39 @@
+package bucketclient_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"io"
+	"net/http"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("CreateMetastoreEntry()", func() {
+	It("creates/updates a new metastore entry", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"POST", "/default/metastore/db/my-bucket",
+			func(req *http.Request) (*http.Response, error) {
+				defer req.Body.Close()
+				Expect(io.ReadAll(req.Body)).To(Equal(
+					[]byte(`{"name":"bucket-03","attributes":"{\"name\":\"bucket-03\"}",` +
+						`"creating":false,"deleting":false,"id":"bucket-03",` +
+						`"raftSessionID":1,"version":2,"raftSession":"rs-1"}`)))
+				return httpmock.NewStringResponse(200, ""), nil
+			},
+		)
+		Expect(client.CreateMetastoreEntry(ctx,
+			"my-bucket", bucketclient.MetastoreEntry{
+				Name:          "bucket-03",
+				Attributes:    `{"name":"bucket-03"}`,
+				Creating:      false,
+				Deleting:      false,
+				ID:            "bucket-03",
+				RaftSessionID: 1,
+				Version:       2,
+				RaftSession:   "rs-1",
+			})).To(Succeed())
+	})
+})

--- a/go/deletemetastoreentry.go
+++ b/go/deletemetastoreentry.go
@@ -1,0 +1,13 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeleteMetastoreEntry deletes the metastore entry for the given bucket
+func (client *BucketClient) DeleteMetastoreEntry(ctx context.Context, bucketName string) error {
+	resource := fmt.Sprintf("/default/metastore/db/%s", bucketName)
+	_, err := client.Request(ctx, "DeleteMetastoreEntry", "DELETE", resource)
+	return err
+}

--- a/go/deletemetastoreentry_test.go
+++ b/go/deletemetastoreentry_test.go
@@ -1,0 +1,31 @@
+package bucketclient_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("DeleteMetastoreEntry()", func() {
+	It("deletes a metastore entry", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"DELETE", "/default/metastore/db/my-bucket",
+			httpmock.NewStringResponder(200, ""),
+		)
+		Expect(client.DeleteMetastoreEntry(ctx, "my-bucket")).To(Succeed())
+	})
+
+	It("return 404 error if bucket does not exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"DELETE", "/default/metastore/db/doesnotexist",
+			httpmock.NewStringResponder(404, ""),
+		)
+		err := client.DeleteMetastoreEntry(ctx, "doesnotexist")
+		Expect(err).To(HaveOccurred())
+		bcErr, ok := err.(*bucketclient.BucketClientError)
+		Expect(ok).To(BeTrue())
+		Expect(bcErr.StatusCode).To(Equal(404))
+	})
+})

--- a/go/getmetastoreentry.go
+++ b/go/getmetastoreentry.go
@@ -1,0 +1,23 @@
+package bucketclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// GetMetastoreEntry retrieves and parses a metastore entry for the given bucket
+func (client *BucketClient) GetMetastoreEntry(ctx context.Context, bucketName string) (MetastoreEntry, error) {
+	resource := fmt.Sprintf("/default/metastore/db/%s", bucketName)
+	responseBody, err := client.Request(ctx, "GetMetastoreEntry", "GET", resource)
+	if err != nil {
+		return MetastoreEntry{}, err
+	}
+	var metastoreEntry MetastoreEntry
+	jsonErr := json.Unmarshal(responseBody, &metastoreEntry)
+	if jsonErr != nil {
+		return MetastoreEntry{}, ErrorMalformedResponse("GetMetastoreEntry",
+			"GET", client.Endpoint, resource, jsonErr)
+	}
+	return metastoreEntry, nil
+}

--- a/go/getmetastoreentry_test.go
+++ b/go/getmetastoreentry_test.go
@@ -1,0 +1,46 @@
+package bucketclient_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var testGetMetastoreEntryResponse = `{"name":"bucket-03","attributes":"{\"name\":\"bucket-03\"}",` +
+	`"creating":false,"deleting":false,"id":"bucket-03","raftSessionID":1,"version":2,` +
+	`"raftSession":"rs-1"}`
+
+var _ = Describe("GetMetastoreEntry()", func() {
+	It("retrieves the parsed metastore entry for a bucket", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "/default/metastore/db/my-bucket",
+			httpmock.NewStringResponder(200, testGetMetastoreEntryResponse),
+		)
+		Expect(client.GetMetastoreEntry(ctx, "my-bucket")).To(
+			Equal(bucketclient.MetastoreEntry{
+				Name:          "bucket-03",
+				Attributes:    `{"name":"bucket-03"}`,
+				Creating:      false,
+				Deleting:      false,
+				ID:            "bucket-03",
+				RaftSessionID: 1,
+				Version:       2,
+				RaftSession:   "rs-1",
+			}))
+	})
+
+	It("returns a 404 error if the bucket does not exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"GET", "/default/metastore/db/my-bucket",
+			httpmock.NewStringResponder(404, ""),
+		)
+		_, err := client.GetMetastoreEntry(ctx, "my-bucket")
+		Expect(err).To(HaveOccurred())
+		bcErr, ok := err.(*bucketclient.BucketClientError)
+		Expect(ok).To(BeTrue())
+		Expect(bcErr.StatusCode).To(Equal(404))
+	})
+})

--- a/go/metastore_types.go
+++ b/go/metastore_types.go
@@ -1,0 +1,12 @@
+package bucketclient
+
+type MetastoreEntry struct {
+	Name          string `json:"name"`
+	Attributes    string `json:"attributes"`
+	Creating      bool   `json:"creating"`
+	Deleting      bool   `json:"deleting"`
+	ID            string `json:"id"`
+	RaftSessionID int    `json:"raftSessionID"`
+	Version       int    `json:"version"`
+	RaftSession   string `json:"raftSession"`
+}


### PR DESCRIPTION
Create the bucketd API functions:
- GetMetastoreEntry
- PutMetastoreEntry
- DeleteMetastoreEntry

Request the path `/default/metastore/db/{bucketname}` on the bucketd endpoint.