### PR TITLE
ft: BKTCLT-32 go client DeleteBucket

### DIFF
--- a/go/deletebucket.go
+++ b/go/deletebucket.go
@@ -1,0 +1,14 @@
+package bucketclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeleteBucket deletes a bucket entry from metadata.
+func (client *BucketClient) DeleteBucket(ctx context.Context, bucketName string) error {
+	resource := fmt.Sprintf("/default/bucket/%s", bucketName)
+
+	_, err := client.Request(ctx, "DeleteBucket", "DELETE", resource)
+	return err
+}

--- a/go/deletebucket_test.go
+++ b/go/deletebucket_test.go
@@ -1,0 +1,32 @@
+package bucketclient_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/scality/bucketclient/go"
+)
+
+var _ = Describe("DeleteBucket()", func() {
+	It("deletes an existing bucket entry", func(ctx SpecContext) {
+		httpmock.RegisterResponder("DELETE", "/default/bucket/my-bucket",
+			httpmock.NewStringResponder(200, ""))
+
+		Expect(client.DeleteBucket(ctx, "my-bucket")).To(Succeed())
+	})
+
+	It("forwards a 404 NotFound error when the bucket doesn't exist", func(ctx SpecContext) {
+		httpmock.RegisterResponder("DELETE", "/default/bucket/my-bucket",
+			httpmock.NewStringResponder(http.StatusNotFound, ""))
+
+		err := client.DeleteBucket(ctx, "my-bucket")
+		Expect(err).To(HaveOccurred())
+		bcErr, ok := err.(*bucketclient.BucketClientError)
+		Expect(ok).To(BeTrue())
+		Expect(bcErr.StatusCode).To(Equal(http.StatusNotFound))
+	})
+})

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.12",
+  "version": "7.10.13",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Implement the DeleteBucket API call, which calls the bucketd route `DELETE /default/bucket/{bucketname}`.