### PR TITLE
BKTCLT-37: Include overhead in PostBatch

### DIFF
--- a/go/postbatch.go
+++ b/go/postbatch.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 )
 
+type Overhead struct {
+	InternalOp bool `json:"internalOp,omitempty"`
+}
+
 type PostBatchEntry struct {
-	Key   string `json:"key"`
-	Value string `json:"value,omitempty"`
-	Type  string `json:"type,omitempty"`
+	Key      string    `json:"key"`
+	Value    string    `json:"value,omitempty"`
+	Overhead *Overhead `json:"overhead,omitempty"`
+	Type     string    `json:"type,omitempty"`
 }
 
 func (client *BucketClient) PostBatch(ctx context.Context,

--- a/go/postbatch_test.go
+++ b/go/postbatch_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/scality/bucketclient/go"
+	bucketclient "github.com/scality/bucketclient/go"
 )
 
 var _ = Describe("PostBatch()", func() {
@@ -18,7 +18,7 @@ var _ = Describe("PostBatch()", func() {
 			func(req *http.Request) (*http.Response, error) {
 				defer req.Body.Close()
 				Expect(io.ReadAll(req.Body)).To(Equal(
-					[]byte(`{"batch":[{"key":"foo","value":"{}"},{"key":"bar","type":"del"}]}`)))
+					[]byte(`{"batch":[{"key":"foo","value":"{}"},{"key":"bar","type":"del"},{"key":"foo","value":"{}","overhead":{"internalOp":true}}]}`)))
 
 				contentType, hasHeader := req.Header["Content-Type"]
 				Expect(hasHeader).To(BeTrue())
@@ -31,6 +31,7 @@ var _ = Describe("PostBatch()", func() {
 		Expect(client.PostBatch(ctx, "somebucket", []bucketclient.PostBatchEntry{
 			{Key: "foo", Value: "{}"},
 			{Key: "bar", Type: "del"},
+			{Key: "foo", Value: "{}", Overhead: &bucketclient.Overhead{InternalOp: true}},
 		})).To(Succeed())
 	})
 })

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.16",
+  "version": "7.10.17",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Allow batches in `PostBatch` to include:
```
overhead: { internalOp: true }
```

To be used by bucket migration. See https://github.com/scality/metadata-migration/pull/65