### PR TITLE
bf: BKTCLT-42 exception "callback was already called"

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -9,7 +9,7 @@ const HttpAgent = require('agentkeepalive');
 const HttpsAgent = require('agentkeepalive').HttpsAgent;
 
 const werelogs = require('werelogs');
-const { errors, constants } = require('arsenal');
+const { errors, constants, jsutil } = require('arsenal');
 
 function errorMap(mdError) {
     const map = {
@@ -341,6 +341,7 @@ class RESTClient {
      * @return {undefined}
      */
     request(method, beginPath, log, params, data, callback) {
+        const callbackOnce = jsutil.once(callback);
         this.requestStreamed(
             method, beginPath, log, params, data, (err, res) => {
                 if (err) {
@@ -351,9 +352,12 @@ class RESTClient {
                 res.on('data', data => {
                     ret.push(data);
                     retLen += data.length;
-                }).on('error', callback)
+                }).on('error', error => {
+                    log.error('error receiving response from metadata', { error: error.toString() });
+                    callbackOnce(errors.InternalError.customizeDescription(error.message));
+                })
                   .on('end', () => {
-                      callback(null, Buffer.concat(ret, retLen).toString());
+                      callbackOnce(null, Buffer.concat(ret, retLen).toString());
                   });
                 return undefined;
             });
@@ -376,6 +380,7 @@ class RESTClient {
         log.debug('sending request', { httpMethod: method, beginPath });
         let path = beginPath;
         assert(typeof callback === 'function', 'callback must be a function');
+        const callbackOnce = jsutil.once(callback);
         const headers = {
             'content-length': 0,
             'x-scal-request-uids': log.getSerializedUids(),
@@ -421,11 +426,11 @@ class RESTClient {
             req.write(binData);
         }
 
-        req.on('response', res => this.endRespond(res, res, log, callback))
+        req.on('response', res => this.endRespond(res, res, log, callbackOnce))
            .on('error', error => {
                // covers system errors like ECONNREFUSED, ECONNRESET etc.
-               log.error('error sending request to metadata', { error });
-               callback(errors.InternalError);
+               log.error('error sending request to metadata', { error: error.toString() });
+               callbackOnce(errors.InternalError.customizeDescription(error.message));
            }).end();
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.19",
+  "version": "7.10.20",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "description": "Bucket Client",
   "main": "index.js",
   "files": [
-      "CONTRIBUTING.md",
-      "config.json",
-      "index.d.ts",
-      "lib/*",
-      "licenses/*",
-      "yarn.lock"
+    "CONTRIBUTING.md",
+    "config.json",
+    "index.d.ts",
+    "lib/*",
+    "licenses/*",
+    "yarn.lock"
   ],
   "scripts": {
     "ft_test": "mocha tests/functional",
@@ -38,7 +38,8 @@
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#7.10.2",
     "eslint-plugin-react": "4.2.3",
-    "mocha": ""
+    "mocha": "",
+    "sinon": "^20.0.0"
   },
   "dependencies": {
     "agentkeepalive": "^4.1.4",

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -1,9 +1,11 @@
 'use strict'; // eslint-disable-line strict
 
 const assert = require('assert');
+const { EventEmitter } = require('events');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+const sinon = require('sinon');
 
 const RESTClient = require('../../index').RESTClient;
 
@@ -218,5 +220,57 @@ Object.keys(env).forEach(key => {
                 return done();
             });
         });
+    });
+});
+
+describe('with a stubbed http.request', () => {
+    let httpRequestStub;
+    let client;
+
+    beforeEach(() => {
+        httpRequestStub = sinon.stub(http, 'request');
+        client = new RESTClient(['bucketclient.testing.local:9000']);
+    });
+
+    afterEach(() => {
+        httpRequestStub.restore();
+        client.agent.destroy();
+    });
+
+    it('should call callback only once if HTTP request stream emits multiple errors', () => {
+        const mockRequest = new EventEmitter();
+        mockRequest.setNoDelay = () => {};
+        mockRequest.end = () => {
+            // emit two errors on the request stream
+            mockRequest.emit('error', new Error('first error'));
+            mockRequest.emit('error', new Error('second error'));
+        };
+        httpRequestStub.callsFake(() => mockRequest);
+
+        const callbackSpy = sinon.spy();
+        client.getObject('foobucket', 'fookey', '', callbackSpy);
+        assert.strictEqual(callbackSpy.callCount, 1);
+        assert.strictEqual(callbackSpy.getCall(0).args[0].code, 500);
+    });
+
+    it('should call callback only once if HTTP response stream emits multiple errors', () => {
+        const mockResponse = new EventEmitter();
+        mockResponse.statusCode = 200;
+
+        const mockRequest = new EventEmitter();
+        mockRequest.setNoDelay = () => {};
+        mockRequest.end = () => {
+            mockRequest.emit('response', mockResponse);
+
+            // emit two errors on the response stream
+            mockResponse.emit('error', new Error('first error'));
+            mockResponse.emit('error', new Error('second error'));
+        };
+        httpRequestStub.callsFake(() => mockRequest);
+
+        const callbackSpy = sinon.spy();
+        client.getObject('foobucket', 'fookey', '', callbackSpy);
+        assert.strictEqual(callbackSpy.callCount, 1);
+        assert.strictEqual(callbackSpy.getCall(0).args[0].code, 500);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,29 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@sinonjs/commons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz#36b9dbc21ad5546486ea9173d6bea063eb1717d5"
+  integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
+"@sinonjs/samsam@^8.0.1":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.2.tgz#e4386bf668ff36c95949e55a38dc5f5892fc2689"
+  integrity sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    lodash.get "^4.4.2"
+    type-detect "^4.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -947,6 +970,11 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 diskusage@^1.1.1:
   version "1.1.3"
@@ -2316,6 +2344,11 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isarguments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3228,6 +3261,17 @@ simple-glob@^0.2:
     lodash.flatten "^4.4.0"
     lodash.union "^4.6.0"
 
+sinon@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-20.0.0.tgz#4b653468735f7152ba694d05498c2b5d024ab006"
+  integrity sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^13.0.5"
+    "@sinonjs/samsam" "^8.0.1"
+    diff "^7.0.0"
+    supports-color "^7.2.0"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -3487,7 +3531,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -3573,6 +3617,16 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 type@^1.0.1:
   version "1.2.0"


### PR DESCRIPTION
Ensure:

- the callback of `RESTClient.request` is only called once if the HTTP response stream emits multiple `error` events

- the callback of `RESTClient.requestStreamed` is only called once if the HTTP request stream emits multiple `error` events

Also normalize the error returned by a response stream error as an Arsenal `InternalError` and log it, to be consistent with handling of request errors.