### PR TITLE
bf: BKTCLT-43 consume response body on HTTP error status

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'bucketclient' {
         appendToLog(bucketName: string, batch: Array<BatchOperation>, raftsession: string | null | undefined, reqUids: string[], callback: Callback, reqLogger: any): void;
         healthcheck(log: any, callback: Callback): void;
         livecheck(log: any, callback: Callback): void;
-        private endRespond(res: any, ret: any, log: any, callback: Callback): void;
+        private endRespond(res: any, log: any, callback: Callback): void;
         private request(method: string, beginPath: string, log: any, params: any, data: any, callback: Callback): void;
         private requestStreamed(method: string, beginPath: string, log: any, params: any, data: any, callback: Callback): void;
     }

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -298,26 +298,24 @@ class RESTClient {
         this.request('POST', '/_/livecheck', log, null, null, callback);
     }
 
-    endRespond(res, ret, log, callback) {
+    endRespond(res, log, callback) {
         const code = res.statusCode;
         if (code <= 201) {
             log.debug('direct request to endpoint returned success',
                 { httpCode: code });
-            return callback(null, ret);
+            return callback(null, res);
         }
 
         let error = errors[errorMap(res.statusMessage)];
         if (error) {
             error.isExpected = true;
-            log.debug('direct request to endpoint returned an expected error', {
-                error });
-            return callback(error, ret);
+        } else {
+            error = errors.InternalError.customizeDescription('unexpected error');
+            error.isExpected = false;
         }
-        error = errors.InternalError.customizeDescription('unexpected error');
-        error.isExpected = false;
-        log.debug('direct request to endpoint returned an unexpected error',
-            { error });
-        return callback(error, ret);
+        log.debug('direct request to endpoint returned an error', { error });
+        res.resume();
+        return callback(error);
     }
 
     /**
@@ -426,7 +424,7 @@ class RESTClient {
             req.write(binData);
         }
 
-        req.on('response', res => this.endRespond(res, res, log, callbackOnce))
+        req.on('response', res => this.endRespond(res, log, callbackOnce))
            .on('error', error => {
                // covers system errors like ECONNREFUSED, ECONNRESET etc.
                log.error('error sending request to metadata', { error: error.toString() });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.20",
+  "version": "7.10.21",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
 const assert = require('assert');
+const async = require('async');
 const { EventEmitter } = require('events');
 const fs = require('fs');
 const http = require('http');
@@ -219,6 +220,22 @@ Object.keys(env).forEach(key => {
                 assert.deepStrictEqual(err, null);
                 return done();
             });
+        });
+
+        it('should be able to reuse a connection after an HTTP error status is received', done => {
+            async.timesSeries(
+                10,
+                (i, next) => client.getRaftInformation(nonExistBucket.name, reqUids, err => {
+                    assert(err.is.NoSuchBucket);
+                    // trigger the node.js event loop after each iteration, to let the HTTP module
+                    // a chance to cleanup the unique connection state and reuse it
+                    setTimeout(next, 10);
+                }),
+                () => {
+                    assert(client.agent.totalSocketCount === 1,
+                        `expected total socket count to be 1, got ${client.agent.totalSocketCount}`);
+                    done();
+                });
         });
     });
 });


### PR DESCRIPTION
Ensure connections can be reused when an HTTP error response is received, by consuming (but ignoring) the response body, as required to avoid the connection becoming not reusable until it is removed from the HTTP agent's connection pool.
