### PR TITLE
BKTCLT-47 [impr] support createBucket to specific session ID

### DIFF
--- a/go/createbucket.go
+++ b/go/createbucket.go
@@ -55,7 +55,7 @@ func (client *BucketClient) CreateBucket(ctx context.Context,
 	resource := fmt.Sprintf("/default/bucket/%s", bucketName)
 	query := url.Values{}
 
-	if parsedOpts.sessionId > 0 {
+	if parsedOpts.sessionId >= 0 {
 		query.Set("raftsession", strconv.Itoa(parsedOpts.sessionId))
 	}
 	u, _ := url.Parse(resource)

--- a/go/createbucket_test.go
+++ b/go/createbucket_test.go
@@ -38,6 +38,19 @@ var _ = Describe("CreateBucket()", func() {
 			bucketclient.CreateBucketSessionIdOption(12))).To(Succeed())
 	})
 
+	It("creates a bucket on raft session 0", func(ctx SpecContext) {
+		httpmock.RegisterResponder(
+			"POST", "/default/bucket/my-new-bucket?raftsession=0",
+			func(req *http.Request) (*http.Response, error) {
+				defer req.Body.Close()
+				Expect(io.ReadAll(req.Body)).To(Equal([]byte(`{"foo":"bar"}`)))
+				return httpmock.NewStringResponse(200, ""), nil
+			},
+		)
+		Expect(client.CreateBucket(ctx, "my-new-bucket", []byte(`{"foo":"bar"}`),
+			bucketclient.CreateBucketSessionIdOption(0))).To(Succeed())
+	})
+
 	It("forwards request error", func(ctx SpecContext) {
 		httpmock.RegisterResponder(
 			"POST", "/default/bucket/my-new-bucket",

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -143,14 +143,27 @@ class RESTClient {
             null, attributes, callback);
     }
 
-    createBucket(bucketName, reqUids, attributes, callback, reqLogger) {
+    /**
+     * Create a bucket
+     *
+     * @param {string} bucketName - bucket name
+     * @param {string} reqUids - the identifier of the request
+     * @param {string} attributes - stringified bucket attributes
+     * @param {function} callback - callback
+     * @param {werelogs.Logger} [reqLogger] - Logger instance
+     * @param {object} [queryParams] - extra query parameters
+     * @param {number} [queryParams.raftsession] - RAFT session ID
+     *
+     * @return {undefined}
+     */
+    createBucket(bucketName, reqUids, attributes, callback, reqLogger, queryParams) {
         const log = reqLogger || this.createLogger(reqUids);
         assert(typeof bucketName === 'string', 'bucketName must be a string');
         assert(typeof attributes === 'string', 'attributes must be a string');
 
         log.debug('createBucket', { bucketName, attr: attributes });
         this.request('POST', `/default/bucket/${bucketName}`, log,
-            null, attributes, callback);
+            queryParams, attributes, callback);
     }
 
     deleteBucket(bucketName, reqUids, callback, reqLogger) {
@@ -163,7 +176,7 @@ class RESTClient {
     }
 
     /**
-     * Create or udpate an object or a version of an object.
+     * Create or update an object or a version of an object.
      * Examples:
      * - creating an object: PUT /foo/bar
      * - updating a version: PUT /foo/bar?versionId=1234567890

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.7",
+  "version": "8.2.8",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -36,7 +36,8 @@ const existObject = {
     name: 'testObject',
     value: { key: 'value', metadata: 'test' },
 };
-const nonExistBucket = { name: 'Ford' };
+const newBucketName = 'new-bucket';
+const newBucketNameWithRSID = 'new-bucket-with-rsid';
 const reqUids = 'REQ1';
 
 let includeRaftSessionIdHeader = true;
@@ -75,10 +76,14 @@ function handler(req, res) {
     if (req.method === 'POST') {
         if (req.url === `/default/bucket/${existBucket.name}`) {
             makeResponse(res, 409, 'BucketAlreadyExists');
-        } else if (req.url === `/default/bucket/${nonExistBucket.name}`) {
+        } else if (req.url === `/default/bucket/${newBucketName}`) {
+            makeResponse(res, 200, 'OK');
+        } else if (req.url === `/default/bucket/${newBucketNameWithRSID}?raftsession=2`) {
             makeResponse(res, 200, 'OK');
         } else if (req.url === '/_/livecheck') {
             makeResponse(res, 200, 'OK');
+        } else {
+            assert.fail(`unexpected POST url: ${req.url}`);
         }
     } else if (req.method === 'GET') {
         if (req.url === `/default/attributes/${existBucket.name}`) {
@@ -134,8 +139,13 @@ Object.keys(env).forEach(key => {
         });
 
         it('should create a new non-existing bucket', done => {
-            client.createBucket(nonExistBucket.name, reqUids,
-                '{ status: "dead" }', done);
+            client.createBucket(newBucketName, reqUids,
+                '{}', done);
+        });
+
+        it('should create a new non-existing bucket on a given RAFT session', done => {
+            client.createBucket(newBucketNameWithRSID, reqUids,
+                '{}', done, null, { raftsession: 2 });
         });
 
         it('should try to create an already existing bucket and fail', done => {
@@ -216,7 +226,7 @@ Object.keys(env).forEach(key => {
         });
 
         it('should get Raft informations on an unexisting bucket', done => {
-            client.getRaftInformation(nonExistBucket.name, reqUids,
+            client.getRaftInformation(newBucketName, reqUids,
                 err => {
                     assert(err.is.NoSuchBucket);
                     assert.strictEqual(err.isExpected, true);
@@ -235,7 +245,7 @@ Object.keys(env).forEach(key => {
         });
 
         it('should get Bucket informations on an unexisting bucket', done => {
-            client.getRaftInformation(nonExistBucket.name, reqUids,
+            client.getRaftInformation(newBucketName, reqUids,
                 err => {
                     assert(err.is.NoSuchBucket);
                     assert.strictEqual(err.isExpected, true);
@@ -245,7 +255,7 @@ Object.keys(env).forEach(key => {
         });
 
         it('should fetch non-existing bucket, sending back an error', done => {
-            client.getBucketAttributes(nonExistBucket.name, reqUids, err => {
+            client.getBucketAttributes(newBucketName, reqUids, err => {
                 if (err) {
                     assert(err.is.NoSuchBucket);
                     assert.strictEqual(err.isExpected, true);
@@ -261,7 +271,7 @@ Object.keys(env).forEach(key => {
         });
 
         it('should fetch non-existing bucket, sending back an error', done => {
-            client.deleteBucket(nonExistBucket.name, reqUids, err => {
+            client.deleteBucket(newBucketName, reqUids, err => {
                 if (err) {
                     assert(err.is.NoSuchBucket);
                     assert.strictEqual(err.isExpected, true);
@@ -300,7 +310,7 @@ Object.keys(env).forEach(key => {
         it('should be able to reuse a connection after an HTTP error status is received', done => {
             async.timesSeries(
                 10,
-                (i, next) => client.getRaftInformation(nonExistBucket.name, reqUids, err => {
+                (i, next) => client.getRaftInformation(newBucketName, reqUids, err => {
                     assert(err.is.NoSuchBucket);
                     // trigger the node.js event loop after each iteration, to let the HTTP module
                     // a chance to cleanup the unique connection state and reuse it


### PR DESCRIPTION
- Add optional query params to the createBucket HTTP request, in particular to allow creating the bucket on a specified RAFT session

- Minor unit test cleanup

- Allow creating buckets on RAFT session 0 via the Go client (sanity checks will be done by bucketd, only in case RS 0 is the map)