### PR TITLE
BKTCLT-48 [impr] add backup re-index routes

### DIFF
--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -538,6 +538,92 @@ class RESTClient {
     }
 
     /**
+     *   send a request to re-index all or a range of backups, with optional re-creation
+     *
+     *   @param {string} raftId - raft session id
+     *   @param {object} [recreateBackupsParams] - backup re-creation params:
+     *     - if null or undefined: do not re-create backups
+     *     - if an object: re-create backups if their params differ from the provided
+     *       params, or from the current configuration when not provided, supported
+     *       optional params are:
+     *       - {number} formatVersion: 1 or 2
+     *       - {string} compression: "none" or "zstd"
+     *       - {number} recreateMinBseq: bseq at which to start re-creating backups
+     *       - {number} recreateMaxBseq: bseq after which to stop re-creating backups
+     *   @param {string} [reqUids] - the identifier of the request
+     *   @param {callback} callback - callback(err)
+     *   @param {werelogs.Logger} [logger] - Logger instance
+     *   @return {undefined}
+     */
+    reindexBackups(raftId, recreateBackupsParams, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        const path = `/_/raft_sessions/${raftId}/backups/reindex`;
+        const query = {};
+        if (recreateBackupsParams) {
+            // activate backup re-creation
+            query.recreateBackups = '';
+            for (const supportedParam of [
+                'formatVersion', 'compression', 'recreateMinBseq', 'recreateMaxBseq',
+            ]) {
+                if (recreateBackupsParams[supportedParam] !== undefined) {
+                    query[supportedParam] = recreateBackupsParams[supportedParam];
+                }
+            }
+        }
+        log.debug('re-index backups route', { raftId, path, query });
+        this.request('POST', path, log, query, null, callback);
+    }
+
+    /**
+     *   send a request to get the running or most recently completed backup re-index
+     *   job status
+     *
+     *   @param {string} raftId - raft session id
+     *   @param {string} [reqUids] - the identifier of the request
+     *   @param {callback} callback - callback(err, info)
+     *   @param {werelogs.Logger} [logger] - Logger instance
+     *   @return {undefined}
+     */
+    getBackupReindexJobStatus(raftId, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        const path = `/_/raft_sessions/${raftId}/backups/reindex`;
+        log.debug('get backup re-index job status', { raftId, path });
+        this.request('GET', path, log, null, null, (err, response) => {
+            if (err) {
+                return callback(err);
+            }
+            let parsedResponse;
+            try {
+                parsedResponse = JSON.parse(response);
+            } catch (err) {
+                log.error('failed to parse JSON response from bucketd', {
+                    method: 'GET',
+                    path,
+                    error: err.message,
+                });
+                return callback(err);
+            }
+            return callback(null, parsedResponse);
+        });
+    }
+
+    /**
+     *   send a request to abort a running backup re-index job
+     *
+     *   @param {string} raftId - raft session id
+     *   @param {string} [reqUids] - the identifier of the request
+     *   @param {callback} callback - callback(err)
+     *   @param {werelogs.Logger} [logger] - Logger instance
+     *   @return {undefined}
+     */
+    abortBackupReindexJob(raftId, reqUids, callback, logger) {
+        const log = logger || this.createLogger(reqUids);
+        const path = `/_/raft_sessions/${raftId}/backups/reindex`;
+        log.debug('abort backup re-index job', { raftId, path });
+        this.request('DELETE', path, log, null, null, callback);
+    }
+
+    /**
     *   Get proper bucket information like raftSessionId or other statuses
     *
     *   @param {string} bucketName - bucketName

--- a/lib/RESTClient.js
+++ b/lib/RESTClient.js
@@ -333,7 +333,7 @@ class RESTClient {
 
     endRespond(res, log, callback) {
         const code = res.statusCode;
-        if (code <= 201) {
+        if (Math.floor(code / 100) <= 2) {
             log.debug('direct request to endpoint returned success',
                 { httpCode: code });
             return callback(null, res);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.8",
+  "version": "8.2.9",
   "description": "Bucket Client",
   "main": "index.js",
   "files": [

--- a/tests/unit/simple_tests.js
+++ b/tests/unit/simple_tests.js
@@ -82,6 +82,13 @@ function handler(req, res) {
             makeResponse(res, 200, 'OK');
         } else if (req.url === '/_/livecheck') {
             makeResponse(res, 200, 'OK');
+        } else if (req.url === '/_/raft_sessions/12/backups/reindex?') {
+            makeResponse(res, 202, 'Accepted');
+        // The order of query params is deterministically defined by the order in which
+        // they are inserted by the RESTClient.reindexBackups method.
+        } else if (req.url === '/_/raft_sessions/12/backups/reindex?recreateBackups=&' +
+                   'formatVersion=2&compression=zstd&recreateMinBseq=10&recreateMaxBseq=20') {
+            makeResponse(res, 202, 'Accepted');
         } else {
             assert.fail(`unexpected POST url: ${req.url}`);
         }
@@ -108,12 +115,25 @@ function handler(req, res) {
             makeResponse(res, 200, 'OK');
         } else if (req.url === '/_/healthcheck/simple') {
             makeResponse(res, 200, 'OK');
+        } else if (req.url === '/_/raft_sessions/12/backups/reindex') {
+            makeResponse(res, 200, 'OK');
+            // example response, pruned of some of its contents for simplicity
+            res.write(JSON.stringify({
+                startTime: '2026-01-13T00:26:50.294Z',
+                status: 'running',
+                repd: {
+                    id: 22,
+                    name: 'md3-cluster1',
+                },
+            }));
         } else {
             makeResponse(res, 404, 'NoSuchBucket');
         }
     } else if (req.method === 'DELETE') {
         if (req.url === `/default/bucket/${existBucket.name}`) {
             makeResponse(res, 200, 'OK');
+        } else if (req.url === '/_/raft_sessions/12/backups/reindex') {
+            makeResponse(res, 204, 'No Content');
         } else {
             makeResponse(res, 404, 'NoSuchBucket');
         }
@@ -321,6 +341,51 @@ Object.keys(env).forEach(key => {
                         `expected total socket count to be 1, got ${client.agent.totalSocketCount}`);
                     done();
                 });
+        });
+
+        it('backup re-index: start job without re-create', done => {
+            const log = e.c.createLogger();
+            client.reindexBackups(12, null, reqUids, err => {
+                assert.ifError(err);
+                return done();
+            }, log);
+        });
+
+        it('backup re-index: start job with re-create params', done => {
+            const log = e.c.createLogger();
+            client.reindexBackups(12, {
+                formatVersion: 2,
+                compression: 'zstd',
+                recreateMinBseq: 10,
+                recreateMaxBseq: 20,
+            }, reqUids, err => {
+                assert.ifError(err);
+                return done();
+            }, log);
+        });
+
+        it('backup re-index: get job status', done => {
+            const log = e.c.createLogger();
+            client.getBackupReindexJobStatus(12, reqUids, (err, jobStatus) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(jobStatus, {
+                    startTime: '2026-01-13T00:26:50.294Z',
+                    status: 'running',
+                    repd: {
+                        id: 22,
+                        name: 'md3-cluster1',
+                    },
+                });
+                return done();
+            }, log);
+        });
+
+        it('backup re-index: abort job', done => {
+            const log = e.c.createLogger();
+            client.abortBackupReindexJob(12, reqUids, err => {
+                assert.ifError(err);
+                return done();
+            }, log);
         });
     });
 });


### PR DESCRIPTION
Add the three backup re-index bucketd routes in the javascript client:

- `ReindexBackups` (`POST /_/raft_sessions/x/backups/reindex`)
- `GetBackupReindexJobStatus` (`GET /_/raft_sessions/x/backups/reindex`)
- `AbortBackupReindexJob` (`DELETE /_/raft_sessions/x/backups/reindex`)
